### PR TITLE
poe: add long description to create-validator cmd

### DIFF
--- a/x/poe/client/cli/tx.go
+++ b/x/poe/client/cli/tx.go
@@ -57,7 +57,7 @@ func NewCreateValidatorCmd() *cobra.Command {
 
 			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
 		},
-		Long: fmt.Println(`Create validator gentx with PoE parameters. Considering this is run pre-genesis
+		Long: fmt.Sprintln(`Create validator gentx with PoE parameters. Considering this is run pre-genesis
 --generate-only flag should be set. Otherwise client will try to connect to non-existent node. Also pass in
 address instead of keyname to --from flag.
 


### PR DESCRIPTION
Added long description to `tx poe create-validator` for offline generation