### PR TITLE
Fix Flaky system tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,8 @@ jobs:
     executor: golang
     parallelism: 1
     steps:
-      - setup_remote_docker
+      - attach_workspace:
+          at: /tmp/workspace
       - checkout
       - restore_cache:
           keys:
@@ -100,10 +101,15 @@ jobs:
           name: Build and run system tests
           command: |
             make test-system
-            mkdir -p /tmp/logs
-            copy testnet/*.out /tmp/logs
       - store_artifacts:
-          path: /tmp/logs
+          path: /go/src/github.com/confio/tgrade/testnet/node0.out
+      - store_artifacts:
+          path: /go/src/github.com/confio/tgrade/testnet/node1.out
+      - store_artifacts:
+          path: /go/src/github.com/confio/tgrade/testnet/node2.out
+      - store_artifacts:
+          path: /go/src/github.com/confio/tgrade/testnet/node3.out
+
   upload-coverage:
     executor: golang
     steps:
@@ -169,6 +175,8 @@ jobs:
     executor: golang
     parallelism: 1
     steps:
+      - attach_workspace:
+            at: /tmp/workspace
       - checkout
       - restore_cache:
           keys:


### PR DESCRIPTION
Resolves #112 

* Archive node outputs
* Cleanup in circleCI setup
* Hard kill pending test nodes on stop

From node outputs, I could see "port already in use" conflicts. With the hard kill this is solved now. I have triggered a couple of rebuilds and they pass now