### PR TITLE
Transfer tx fees to valset contract

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 This repository contains code copied from https://github.com/cosmos/cosmos-sdk/tree/v0.42.9
 
-In the x/poe module code from x/gentx and x/staking was repurposed and modified from there on.
+In the x/poe module code from x/gentx, x/staking, x/slashing and x/auth was repurposed and modified from there on.
 
 Credits and a big thank you to the original authors!

--- a/app/app.go
+++ b/app/app.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
-	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/evidence"
 	evidencekeeper "github.com/cosmos/cosmos-sdk/x/evidence/keeper"
 	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
@@ -126,15 +125,12 @@ var (
 
 	// module account permissions
 	maccPerms = map[string][]string{
-		authtypes.FeeCollectorName:  nil,
 		ibctransfertypes.ModuleName: {authtypes.Minter, authtypes.Burner},
 		twasm.ModuleName:            {authtypes.Minter, authtypes.Burner},
 	}
 
 	// module accounts that are allowed to receive tokens
-	allowedReceivingModAcc = map[string]bool{
-		distrtypes.ModuleName: true,
-	}
+	allowedReceivingModAcc = map[string]bool{}
 )
 
 // Verify app interface at compile time
@@ -399,6 +395,7 @@ func NewTgradeApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest
 	anteHandler := globalfee.NewAnteHandler(
 		app.accountKeeper, app.bankKeeper, authante.DefaultSigVerificationGasConsumer,
 		encodingConfig.TxConfig.SignModeHandler(), app.getSubspace(globalfee.ModuleName),
+		app.poeKeeper,
 	)
 	app.SetAnteHandler(anteHandler)
 	app.SetEndBlocker(app.EndBlocker)
@@ -433,7 +430,7 @@ func NewTgradeApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest
 // Name returns the name of the App
 func (app *TgradeApp) Name() string { return app.BaseApp.Name() }
 
-// application updates every begin block
+// BeginBlocker application updates every begin block
 func (app *TgradeApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 	return app.mm.BeginBlock(ctx, req)
 }

--- a/testing/cli.go
+++ b/testing/cli.go
@@ -160,6 +160,14 @@ func (c TgradeCli) GetTendermintValidatorSet() rpc.ResultValidatorsOutput {
 	return res
 }
 
+// GetPoEContractAddress query the PoE contract address
+func (c TgradeCli) GetPoEContractAddress(v string) string {
+	qRes := c.CustomQuery("q", "poe", "contract-address", v)
+	addr := gjson.Get(qRes, "address").String()
+	require.NotEmpty(c.t, addr, "got %q", addr)
+	return addr
+}
+
 // RequireTxSuccess require the received response to contain the success code
 func RequireTxSuccess(t *testing.T, got string) {
 	t.Helper()

--- a/testing/genesis_mutators.go
+++ b/testing/genesis_mutators.go
@@ -1,0 +1,51 @@
+package testing
+
+import (
+	"encoding/json"
+	"fmt"
+	poetypes "github.com/confio/tgrade/x/poe/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+	"testing"
+)
+
+// SetPoEParamsMutator set params in genesis
+func SetPoEParamsMutator(t *testing.T, params poetypes.Params) GenesisMutator {
+	return func(genesis []byte) []byte {
+		t.Helper()
+		val, err := json.Marshal(params)
+		require.NoError(t, err)
+		state, err := sjson.SetRawBytes(genesis, "app_state.poe.params", val)
+		require.NoError(t, err)
+		return state
+	}
+}
+
+// SetGlobalMinFee set the passed coins to the global minimum fee
+func SetGlobalMinFee(t *testing.T, fees ...sdk.DecCoin) GenesisMutator {
+	return func(genesis []byte) []byte {
+		t.Helper()
+		coins := sdk.NewDecCoins(fees...)
+		require.NoError(t, coins.Validate())
+		val, err := json.Marshal(coins)
+		require.NoError(t, err)
+		state, err := sjson.SetRawBytes(genesis, "app_state.globalfee.params.minimum_gas_prices", val)
+		require.NoError(t, err)
+		return state
+	}
+}
+
+// SetAllEngagementPoints set the given value for all members of the engament group (default = validators)
+func SetAllEngagementPoints(t *testing.T, points int) GenesisMutator {
+	return func(raw []byte) []byte {
+		group := gjson.GetBytes(raw, "app_state.poe.engagement").Array()
+		for i := range group {
+			var err error
+			raw, err = sjson.SetRawBytes(raw, fmt.Sprintf("app_state.poe.engagement.%d.weight", i), []byte(fmt.Sprintf(`"%d"`, points)))
+			require.NoError(t, err)
+		}
+		return raw
+	}
+}

--- a/testing/main_test.go
+++ b/testing/main_test.go
@@ -135,3 +135,9 @@ func encodeBech32Addr(src []byte) string {
 func ContractBech32Address(codeID, instanceID uint64) string {
 	return encodeBech32Addr(wasmkeeper.BuildContractAddress(codeID, instanceID))
 }
+
+func AwaitValsetEpochCompleted(t *testing.T) {
+	// wait for update manifests in valset (epoch has completed)
+	time.Sleep(time.Second)
+	sut.AwaitNextBlock(t)
+}

--- a/testing/system.go
+++ b/testing/system.go
@@ -670,9 +670,10 @@ func restoreOriginalGenesis(t *testing.T, s SystemUnderTest) {
 func restoreOriginalKeyring(t *testing.T, s SystemUnderTest) {
 	dest := filepath.Join(workDir, s.outputDir, "keyring-test")
 	require.NoError(t, os.RemoveAll(dest))
-
-	src := filepath.Join(workDir, s.nodePath(0), "keyring-test")
-	require.NoError(t, copyFilesInDir(src, dest))
+	for i := 0; i < s.initialNodesCount; i++ {
+		src := filepath.Join(workDir, s.nodePath(i), "keyring-test")
+		require.NoError(t, copyFilesInDir(src, dest))
+	}
 }
 
 // copyFile copy source file to dest file path

--- a/x/globalfee/ante.go
+++ b/x/globalfee/ante.go
@@ -2,6 +2,8 @@ package globalfee
 
 import (
 	"github.com/confio/tgrade/x/globalfee/types"
+	"github.com/confio/tgrade/x/poe"
+	poekeeper "github.com/confio/tgrade/x/poe/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -13,10 +15,11 @@ import (
 
 func NewAnteHandler(
 	ak authkeeper.AccountKeeper,
-	bankKeeper bankkeeper.Keeper,
+	bankKeeper bankkeeper.SendKeeper,
 	sigGasConsumer ante.SignatureVerificationGasConsumer,
 	signModeHandler signing.SignModeHandler,
 	paramStore paramtypes.Subspace,
+	contractSource poekeeper.ContractSource,
 ) sdk.AnteHandler {
 	// list of ante handlers copied from https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/x/auth/ante/ante.go#L17-L31
 	// only NewGlobalMinimumChainFeeDecorator was added
@@ -32,7 +35,7 @@ func NewAnteHandler(
 		ante.NewRejectFeeGranterDecorator(),
 		ante.NewSetPubKeyDecorator(ak), // SetPubKeyDecorator must be called before all signature verification decorators
 		ante.NewValidateSigCountDecorator(ak),
-		ante.NewDeductFeeDecorator(ak, bankKeeper),
+		poe.NewDeductFeeDecorator(bankKeeper, contractSource),
 		ante.NewSigGasConsumeDecorator(ak, sigGasConsumer),
 		ante.NewSigVerificationDecorator(ak, signModeHandler),
 		ante.NewIncrementSequenceDecorator(ak),

--- a/x/poe/ante.go
+++ b/x/poe/ante.go
@@ -1,0 +1,55 @@
+package poe
+
+import (
+	"fmt"
+	"github.com/confio/tgrade/x/poe/keeper"
+	"github.com/confio/tgrade/x/poe/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+type bankKeeper interface {
+	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
+}
+
+// DeductFeeDecorator deducts fees from the first signer of the tx
+// If the first signer does not have the funds to pay for the fees, return with InsufficientFunds error
+// Calls next AnteHandler on success
+// CONTRACT: Tx must implement FeeTx interface to use DeductFeeDecorator
+type DeductFeeDecorator struct {
+	bankKeeper     bankKeeper
+	contractSource keeper.ContractSource
+}
+
+func NewDeductFeeDecorator(bk bankKeeper, cs keeper.ContractSource) DeductFeeDecorator {
+	return DeductFeeDecorator{
+		bankKeeper:     bk,
+		contractSource: cs,
+	}
+}
+
+func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+	}
+
+	feePayer := feeTx.FeePayer()
+	feeCollector, err := dfd.contractSource.GetPoEContractAddress(ctx, types.PoEContractTypeValset)
+	if err != nil {
+		panic(fmt.Sprintf("%s contract address has not been set", types.PoEContractTypeValset))
+	}
+
+	if fee := feeTx.GetFee(); !fee.IsZero() {
+		// deduct the fees
+		if !fee.IsValid() {
+			return ctx, sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "invalid fee amount: %s", fee)
+		}
+		if err := dfd.bankKeeper.SendCoins(ctx, feePayer, feeCollector, fee); err != nil {
+			return ctx, sdkerrors.Wrapf(sdkerrors.ErrInsufficientFunds, err.Error())
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}

--- a/x/poe/ante_test.go
+++ b/x/poe/ante_test.go
@@ -1,0 +1,126 @@
+package poe
+
+import (
+	"errors"
+	"github.com/confio/tgrade/x/poe/keeper"
+	"github.com/confio/tgrade/x/poe/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/rand"
+	"testing"
+)
+
+func TestDeductFeeDecorator(t *testing.T) {
+	var (
+		myContractAddr sdk.AccAddress = rand.Bytes(sdk.AddrLen)
+		mySenderAddr   sdk.AccAddress = rand.Bytes(sdk.AddrLen)
+	)
+
+	cs := keeper.PoEKeeperMock{GetPoEContractAddressFn: func(ctx sdk.Context, ctype types.PoEContractType) (sdk.AccAddress, error) {
+		require.Equal(t, types.PoEContractTypeValset, ctype)
+		return myContractAddr, nil
+	}}
+
+	specs := map[string]struct {
+		feeAmount sdk.Coins
+		bankMock  bankKeeper
+		expErr    bool
+	}{
+		"with fee": {
+			feeAmount: sdk.Coins{sdk.NewCoin("ALX", sdk.OneInt())},
+			bankMock: bankKeeperMock{func(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error {
+				assert.Equal(t, mySenderAddr, fromAddr)
+				assert.Equal(t, myContractAddr, toAddr)
+				assert.Equal(t, sdk.Coins{sdk.NewCoin("ALX", sdk.OneInt())}, amt)
+				return nil
+			}},
+		},
+		"zero fee": {
+			feeAmount: sdk.Coins{sdk.NewCoin("ALX", sdk.ZeroInt())},
+			bankMock:  bankKeeperMock{},
+		},
+		"invalid denom fee": {
+			feeAmount: sdk.Coins{sdk.Coin{Denom: "ALX$%^&", Amount: sdk.OneInt()}},
+			bankMock:  bankKeeperMock{},
+			expErr:    true,
+		},
+		"with multiple fees": {
+			feeAmount: sdk.Coins{sdk.NewCoin("ALX", sdk.OneInt()), sdk.NewCoin("BLX", sdk.NewInt(2))},
+			bankMock: bankKeeperMock{func(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error {
+				assert.Equal(t, mySenderAddr, fromAddr)
+				assert.Equal(t, myContractAddr, toAddr)
+				assert.Equal(t, sdk.Coins{sdk.NewCoin("ALX", sdk.OneInt()), sdk.NewCoin("BLX", sdk.NewInt(2))}, amt)
+				return nil
+			}},
+		},
+		"with multiple fees one amount is zero": {
+			feeAmount: sdk.Coins{sdk.NewCoin("ALX", sdk.ZeroInt()), sdk.NewCoin("BLX", sdk.NewInt(2))},
+			bankMock:  bankKeeperMock{},
+			expErr:    true,
+		},
+		"with multiple fees one denom is invalid": {
+			feeAmount: sdk.Coins{sdk.Coin{Denom: "ALX$%^&", Amount: sdk.OneInt()}, sdk.NewCoin("BLX", sdk.NewInt(2))},
+			bankMock:  bankKeeperMock{},
+			expErr:    true,
+		},
+		"bank send fails": {
+			feeAmount: sdk.Coins{sdk.NewCoin("ALX", sdk.OneInt()), sdk.NewCoin("BLX", sdk.NewInt(2))},
+			bankMock: bankKeeperMock{func(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error {
+				return errors.New("testing")
+			}},
+			expErr: true,
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			nextAnte, gotCalled := captureNextHandlerCall()
+			ctx := sdk.Context{}
+			decorator := NewDeductFeeDecorator(spec.bankMock, cs)
+			_, gotErr := decorator.AnteHandle(ctx, newFeeTXMock(spec.feeAmount, mySenderAddr), false, nextAnte)
+			if spec.expErr {
+				require.Error(t, gotErr)
+				return
+			}
+			require.NoError(t, gotErr)
+			assert.True(t, *gotCalled, "next ante handler called")
+		})
+	}
+}
+
+type bankKeeperMock struct {
+	SendCoinsFn func(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
+}
+
+func (m bankKeeperMock) SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error {
+	if m.SendCoinsFn == nil {
+		panic("not expected to be called")
+	}
+	return m.SendCoinsFn(ctx, fromAddr, toAddr, amt)
+}
+
+func captureNextHandlerCall() (sdk.AnteHandler, *bool) {
+	var called bool
+	return func(ctx sdk.Context, tx sdk.Tx, simulate bool) (newCtx sdk.Context, err error) {
+		called = true
+		return ctx, nil
+	}, &called
+}
+
+type feeTXMock struct {
+	sdk.FeeTx
+	fee   sdk.Coins
+	payer sdk.AccAddress
+}
+
+func newFeeTXMock(fee sdk.Coins, payer sdk.AccAddress) *feeTXMock {
+	return &feeTXMock{fee: fee, payer: payer}
+}
+
+func (f feeTXMock) GetFee() sdk.Coins {
+	return f.fee
+}
+
+func (f feeTXMock) FeePayer() sdk.AccAddress {
+	return f.payer
+}


### PR DESCRIPTION
Resolves #143 

* Replaces SDK `DeductFeeDecorator` with a customized version
* System test to verify fees are distributed to validators
* Minor cleanup in testing package

For reference: this code is based on https://github.com/cosmos/cosmos-sdk/blob/v0.42.9/x/auth/ante/fee.go#L57-L113