### PR TITLE
[do not merge] Add limit gas ante handler

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -28,10 +28,12 @@ func NewAnteHandler(
 	paramStore paramtypes.Subspace,
 	contractSource poekeeper.ContractSource,
 ) sdk.AnteHandler {
+	var max sdk.Gas = 3_000_000
 	// initial version copied from sdk https://github.com/cosmos/cosmos-sdk/blob/v0.42.9/x/auth/ante/ante.go
 	// globalfee was added and poe.NewDeductFeeDecorator replaces ante.NewDeductFeeDecorator
 	return sdk.ChainAnteDecorators(
 		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
+		NewLimitSimulationGasDecorator(&max),
 		wasmkeeper.NewCountTXDecorator(txCounterStoreKey),
 		ante.NewRejectExtensionOptionsDecorator(),
 		ante.NewMempoolFeeDecorator(),

--- a/app/limitgas_ante.go
+++ b/app/limitgas_ante.go
@@ -1,0 +1,33 @@
+package app
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+type LimitSimulationGasDecorator struct {
+	gasLimit *sdk.Gas
+}
+
+// NewLimitSimulationGasDecorator constructor accepts nil value to fallback to block gas limit
+func NewLimitSimulationGasDecorator(gasLimit *sdk.Gas) *LimitSimulationGasDecorator {
+	return &LimitSimulationGasDecorator{gasLimit: gasLimit}
+}
+
+func (d LimitSimulationGasDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if !simulate {
+		// Wasm code is not executed in checkTX so that we don't need to limit it further.
+		// Tendermint rejects the TX afterwards when the tx.gas > max block gas.
+		// On deliverTX we rely on the tendermint/sdk mechanics that ensure
+		// tx has gas set and gas < max block gas
+		return next(ctx, tx, simulate)
+	}
+
+	// apply custom node gas limit
+	if d.gasLimit != nil {
+		return next(ctx.WithGasMeter(sdk.NewGasMeter(*d.gasLimit)), tx, simulate)
+	}
+
+	// default to max block gas instead of infinite to be on the safe side
+	if maxGas := ctx.ConsensusParams().GetBlock().MaxGas; maxGas > 0 {
+		return next(ctx.WithGasMeter(sdk.NewGasMeter(sdk.Gas(maxGas))), tx, simulate)
+	}
+	return next(ctx, tx, simulate)
+}


### PR DESCRIPTION
This is the ante handler that will go into wasmd. Early version without tests for fast feedback.
It prevents the simulation scenarios but needs some better testing.