### PR TITLE
Add all wasmd queries

### DIFF
--- a/cmd/tgrade/genwasm.go
+++ b/cmd/tgrade/genwasm.go
@@ -12,7 +12,7 @@ func AddGenesisWasmMsgCmd(defaultNodeHome string) *cobra.Command {
 	txCmd := &cobra.Command{
 		Use:                        "wasm-genesis-message",
 		Short:                      "Wasm genesis message subcommands",
-		Aliases:                    []string{"wasm-genesis-msg", "wasm-genesis-messages"},
+		Aliases:                    []string{"wasm-genesis-msg", "wasm-genesis-messages", "add-wasm-genesis-message"},
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,

--- a/x/twasm/client/cli/query.go
+++ b/x/twasm/client/cli/query.go
@@ -22,18 +22,13 @@ func GetQueryCmd() *cobra.Command {
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}
+
 	queryCmd.AddCommand(
 		GetCmdShowPrivilegedContracts(),
 		GetCmdListPrivilegedContracts(),
-
-		// wasm
-		wasmcli.GetCmdListCode(),
-		wasmcli.GetCmdListContractByCode(),
-		wasmcli.GetCmdQueryCode(),
-		wasmcli.GetCmdGetContractInfo(),
-		wasmcli.GetCmdGetContractHistory(),
-		wasmcli.GetCmdGetContractState(),
 	)
+	// add all wasmd queries
+	queryCmd.AddCommand(wasmcli.GetQueryCmd().Commands()...)
 	return queryCmd
 }
 


### PR DESCRIPTION
I have noticed that the new `pinned` query was not added to tgrade. Instead of manually adding/ maintaining them, we can just add them all instead

`add-wasm-genesis-message` is the cmd used in wasmd. Adding it as an alias for sanity