### PR TITLE
Default testnet denom metadata

### DIFF
--- a/cmd/tgrade/testnet.go
+++ b/cmd/tgrade/testnet.go
@@ -337,6 +337,17 @@ func initGenFiles(
 	clientCtx.Codec.MustUnmarshalJSON(appGenState[banktypes.ModuleName], &bankGenState)
 
 	bankGenState.Balances = genBalances
+	bankGenState.DenomMetadata = []banktypes.Metadata{
+		{
+			Description: "The native staking token of test chain",
+			DenomUnits: []*banktypes.DenomUnit{
+				{Denom: "utgd", Aliases: []string{"microtgd"}},
+				{Denom: "tgd", Exponent: 6},
+			},
+			Base:    "utgd",
+			Display: "tgd",
+		},
+	}
 	appGenState[banktypes.ModuleName] = clientCtx.Codec.MustMarshalJSON(&bankGenState)
 	poeGenesisState := poetypes.GetGenesisStateFromAppState(clientCtx.Codec, appGenState)
 	for i, addr := range genAccounts {


### PR DESCRIPTION
Resolves #229 

Default values in testnet setup as a template in genesis:
```json
{
  "metadatas": [
    {
      "description": "The native staking token of test chain",
      "denom_units": [
        {
          "denom": "utgd",
          "aliases": [
            "microtgd"
          ]
        },
        {
          "denom": "tgd",
          "exponent": 6
        }
      ],
      "base": "utgd",
      "display": "tgd"
    }
  ],
  "pagination": {
    "total": "1"
  }
}
```