### PR TITLE
Upgrade CircleCI docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   golang:
     docker:
-      - image: circleci/golang:1.17
+      - image: cimg/go:1.17.6
 #        user: root # for local testing: https://github.com/CircleCI-Public/circleci-cli/issues/291
     working_directory: /go/src/github.com/confio/tgrade
 


### PR DESCRIPTION
 Issue https://github.com/confio/tgrade/issues/116

Circleci recommends using v 1.17.6 
https://circleci.com/developer/images/image/cimg/go

Do we need to sync with Dockerfile and go.mod as well?
It is v1.17 right now.
Please advice.