### PR TITLE
Use default client coded to work with Rosetta

### DIFF
--- a/cmd/tgrade/root.go
+++ b/cmd/tgrade/root.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
-	clientcodec "github.com/CosmWasm/wasmd/x/wasm/client/codec"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -51,7 +50,7 @@ func NewRootCmd() (*cobra.Command, appparams.EncodingConfig) {
 	cfg.Seal()
 
 	initClientCtx := client.Context{}.
-		WithCodec(clientcodec.NewProtoCodec(encodingConfig.Codec, encodingConfig.InterfaceRegistry)).
+		WithCodec(encodingConfig.Codec).
 		WithInterfaceRegistry(encodingConfig.InterfaceRegistry).
 		WithTxConfig(encodingConfig.TxConfig).
 		WithLegacyAmino(encodingConfig.Amino).


### PR DESCRIPTION
Resolves #274 

Use default codec instead