### PR TITLE
Support vesting testnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ test-unit:
 	@VERSION=$(VERSION) go test -mod=readonly -tags='ledger test_ledger_mock' ./...
 
 test-system: install
-	@VERSION=$(VERSION) go test -mod=readonly -tags='ledger test_ledger_mock system_test' ./testing --wait-time=45s --verbose
+	@VERSION=$(VERSION) go test -mod=readonly -failfast -tags='ledger test_ledger_mock system_test' ./testing --wait-time=45s --verbose
 
 test-race:
 	@VERSION=$(VERSION) go test -mod=readonly -race -tags='ledger test_ledger_mock' ./...

--- a/testing/poe_test.go
+++ b/testing/poe_test.go
@@ -378,7 +378,7 @@ func TestPoEQueries(t *testing.T) {
 			query: []string{"q", "poe", "self-delegation", cli.GetKeyAddr("node0")},
 			assert: func(t *testing.T, qResult string) {
 				delegatedAmount := gjson.Get(qResult, "balance.amount").Int()
-				assert.Equal(t, int64(100000000), delegatedAmount)
+				assert.Equal(t, int64(700000000), delegatedAmount)
 			},
 		},
 		"unbonding delegations": {


### PR DESCRIPTION
Adds a new param to the `testnet` command:
```
--vesting-validators           validators are setup with vesting accounts
```