### PR TITLE
Check for other contract instances before unpinning code

### DIFF
--- a/x/twasm/keeper/privileged.go
+++ b/x/twasm/keeper/privileged.go
@@ -86,7 +86,7 @@ func (k Keeper) UnsetPrivileged(ctx sdk.Context, contractAddr sdk.AccAddress) er
 	if isUniqueContractInstance {
 		// remove from cache
 		if err := k.contractKeeper.UnpinCode(ctx, contractInfo.CodeID); err != nil {
-			return sdkerrors.Wrapf(err, "unpin")
+			return sdkerrors.Wrap(err, "unpin")
 		}
 	}
 

--- a/x/twasm/keeper/privileged.go
+++ b/x/twasm/keeper/privileged.go
@@ -74,9 +74,20 @@ func (k Keeper) UnsetPrivileged(ctx sdk.Context, contractAddr sdk.AccAddress) er
 		return sdkerrors.Wrap(wasmtypes.ErrNotFound, "contractAddr")
 	}
 
-	// remove from cache
-	if err := k.contractKeeper.UnpinCode(ctx, contractInfo.CodeID); err != nil {
-		return sdkerrors.Wrapf(err, "unpin")
+	isUniqueContractInstance := true
+	k.Keeper.IterateContractsByCode(ctx, contractInfo.CodeID, func(address sdk.AccAddress) bool {
+		if !contractAddr.Equals(address) {
+			isUniqueContractInstance = false
+			return true
+		}
+		return false
+	})
+
+	if isUniqueContractInstance {
+		// remove from cache
+		if err := k.contractKeeper.UnpinCode(ctx, contractInfo.CodeID); err != nil {
+			return sdkerrors.Wrapf(err, "unpin")
+		}
 	}
 
 	// remove privileged flag


### PR DESCRIPTION
Resolves #30 

Fix UnsetPrivileged method to unpin code only if there are no other contract instances with same code