### PR TITLE
Address the linter warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,8 @@ jobs:
 
   test-cover:
     executor: golang
-    parallelism: 2 # must not be more than number of packages with code
+    parallelism: 4 # must not be more than number of packages with code
+    resource_class: large
     steps:
       - setup_remote_docker:
           # >= v20.10 https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
   test-system:
     executor: golang
     parallelism: 1
+    resource_class: large
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -114,7 +115,7 @@ jobs:
   simulations:
     executor: golang
     parallelism: 1
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - run:
@@ -249,10 +250,10 @@ workflows:
             - test-cover
       - test-system:
           requires:
-            - setup-dependencies
+            - test-cover
       - gosec:
           requires:
             - setup-dependencies
       - simulations:
           requires:
-            - setup-dependencies
+            - test-cover

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - misspell
     - nakedret
     - prealloc

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,17 +9,16 @@ linters:
     - gocritic
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosec
     - gosimple
     - govet
     - ineffassign
     - interfacer
     - misspell
-    - maligned
     - nakedret
     - prealloc
-    - scopelint
+    - exportloopref
     - staticcheck
     - structcheck
     - stylecheck
@@ -27,6 +26,7 @@ linters:
     - unconvert
     - unused
     - varcheck
+    - gofumpt
 
 issues:
   exclude-rules:
@@ -40,14 +40,11 @@ issues:
 linters-settings:
   dogsled:
     max-blank-identifiers: 3
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
   errcheck:
     # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
     # default is false: such cases aren't reported by default.
     check-blank: true
-  golint:
+  revive:
     # minimal confidence for issues, default is 0.8
     min-confidence: 0
   prealloc:

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ format-tools:
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4
 
 lint: format-tools
-	golangci-lint run
+	golangci-lint run --tests=false
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" | xargs gofumpt -d -s
 
 format: format-tools

--- a/app/app.go
+++ b/app/app.go
@@ -155,9 +155,6 @@ var (
 		twasm.ModuleName:            {authtypes.Minter, authtypes.Burner},
 		poetypes.BondedPoolName:     {authtypes.Burner, authtypes.Staking},
 	}
-
-	// module accounts that are allowed to receive tokens
-	allowedReceivingModAcc = map[string]bool{}
 )
 
 var (

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -133,25 +133,6 @@ func TestGetMaccPerms(t *testing.T) {
 	require.Equal(t, maccPerms, dup, "duplicated module account permissions differed from actual module account permissions")
 }
 
-func setGenesis(gapp *TgradeApp) error {
-	genesisState := NewDefaultGenesisState()
-	stateBytes, err := json.MarshalIndent(genesisState, "", " ")
-	if err != nil {
-		return err
-	}
-
-	// Initialize the chain
-	gapp.InitChain(
-		abci.RequestInitChain{
-			Validators:    []abci.ValidatorUpdate{},
-			AppStateBytes: stateBytes,
-		},
-	)
-
-	gapp.Commit()
-	return nil
-}
-
 func TestIBCKeeperLazyInitialization(t *testing.T) {
 	db := db.NewMemDB()
 	gapp := NewTgradeApp(log.NewTMLogger(log.NewSyncWriter(os.Stdout)), db, nil, true, map[int64]bool{}, DefaultNodeHome, 0, MakeEncodingConfig(), EmptyBaseAppOptions{}, emptyWasmOpts)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -24,7 +24,8 @@ import (
 	poetypes "github.com/confio/tgrade/x/poe/types"
 )
 
-var emptyWasmOpts []wasm.Option = nil
+// default empty opts = nil
+var emptyWasmOpts []wasm.Option
 
 func TestTgradeExport(t *testing.T) {
 	db := db.NewMemDB()

--- a/app/export.go
+++ b/app/export.go
@@ -37,7 +37,7 @@ func (app *TgradeApp) ExportAppStateAndValidators(
 		return servertypes.ExportedApp{}, err
 	}
 
-	validators, err := activeValidatorSet(app, ctx, err)
+	validators, err := activeValidatorSet(app, ctx)
 	if err != nil {
 		return servertypes.ExportedApp{}, err
 	}
@@ -49,10 +49,11 @@ func (app *TgradeApp) ExportAppStateAndValidators(
 	}, err
 }
 
-func activeValidatorSet(app *TgradeApp, ctx sdk.Context, err error) ([]tmtypes.GenesisValidator, error) {
+func activeValidatorSet(app *TgradeApp, ctx sdk.Context) ([]tmtypes.GenesisValidator, error) {
 	var result []tmtypes.GenesisValidator
 	valset := app.poeKeeper.ValsetContract(ctx)
-	valset.IterateActiveValidators(ctx, func(c contract.ValidatorInfo) bool {
+	var err error
+	xerr := valset.IterateActiveValidators(ctx, func(c contract.ValidatorInfo) bool {
 		var opAddr sdk.AccAddress
 		opAddr, err = sdk.AccAddressFromBech32(c.Operator)
 		if err != nil {
@@ -85,5 +86,8 @@ func activeValidatorSet(app *TgradeApp, ctx sdk.Context, err error) ([]tmtypes.G
 		})
 		return false
 	}, nil)
+	if xerr != nil {
+		return nil, xerr
+	}
 	return result, err
 }

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -196,7 +196,7 @@ func SetupWithGenesisAccounts(genAccs []authtypes.GenesisAccount, balances ...ba
 type GenerateAccountStrategy func(int) []sdk.AccAddress
 
 // createRandomAccounts is a strategy used by addTestAddrs() in order to generated addresses in random order.
-func createRandomAccounts(accNum int) []sdk.AccAddress {
+func createRandomAccounts(accNum int) []sdk.AccAddress { //nolint:deadcode,unused
 	testAddrs := make([]sdk.AccAddress, accNum)
 	for i := 0; i < accNum; i++ {
 		pk := ed25519.GenPrivKey().PubKey()
@@ -207,8 +207,8 @@ func createRandomAccounts(accNum int) []sdk.AccAddress {
 }
 
 // createIncrementalAccounts is a strategy used by addTestAddrs() in order to generated addresses in ascending order.
-func createIncrementalAccounts(accNum int) []sdk.AccAddress {
-	var addresses []sdk.AccAddress
+func createIncrementalAccounts(accNum int) []sdk.AccAddress { //nolint:deadcode,unused
+	var addresses []sdk.AccAddress //nolint:prealloc
 	var buffer bytes.Buffer
 
 	// start at 100 so we can make up to 999 test addresses with valid test addresses
@@ -216,72 +216,16 @@ func createIncrementalAccounts(accNum int) []sdk.AccAddress {
 		numString := strconv.Itoa(i)
 		buffer.WriteString("A58856F0FD53BF058B4909A21AEC019107BA6") // base address string
 
-		buffer.WriteString(numString) // adding on final two digits to make addresses unique
-		res, _ := sdk.AccAddressFromHex(buffer.String())
+		buffer.WriteString(numString)                    // adding on final two digits to make addresses unique
+		res, _ := sdk.AccAddressFromHex(buffer.String()) //nolint:errcheck
 		bech := res.String()
-		addr, _ := TestAddr(buffer.String(), bech)
+		addr, _ := TestAddr(buffer.String(), bech) //nolint:errcheck
 
 		addresses = append(addresses, addr)
 		buffer.Reset()
 	}
 
 	return addresses
-}
-
-// AddTestAddrsFromPubKeys adds the addresses into the TgradeApp providing only the public keys.
-//func AddTestAddrsFromPubKeys(app *TgradeApp, ctx sdk.Context, pubKeys []cryptotypes.PubKey, accAmt sdk.Int) {
-//	initCoins := sdk.NewCoins(sdk.NewCoin(app.stakingKeeper.BondDenom(ctx), accAmt))
-//
-//	setTotalSupply(app, ctx, accAmt, len(pubKeys))
-//
-//	// fill all the addresses with some coins, set the loose pool tokens simultaneously
-//	for _, pubKey := range pubKeys {
-//		saveAccount(app, ctx, sdk.AccAddress(pubKey.Address()), initCoins)
-//	}
-//}
-//
-//// setTotalSupply provides the total supply based on accAmt * totalAccounts.
-//func setTotalSupply(app *TgradeApp, ctx sdk.Context, accAmt sdk.Int, totalAccounts int) {
-//	totalSupply := sdk.NewCoins(sdk.NewCoin(app.stakingKeeper.BondDenom(ctx), accAmt.MulRaw(int64(totalAccounts))))
-//	prevSupply := app.bankKeeper.GetSupply(ctx)
-//	app.bankKeeper.SetSupply(ctx, banktypes.NewSupply(prevSupply.GetTotal().Add(totalSupply...)))
-//}
-
-// AddTestAddrs constructs and returns accNum amount of accounts with an
-// initial balance of accAmt in random order
-//func AddTestAddrs(app *TgradeApp, ctx sdk.Context, accNum int, accAmt sdk.Int) []sdk.AccAddress {
-//	return addTestAddrs(app, ctx, accNum, accAmt, createRandomAccounts)
-//}
-
-// AddTestAddrs constructs and returns accNum amount of accounts with an
-// initial balance of accAmt in random order
-//func AddTestAddrsIncremental(app *TgradeApp, ctx sdk.Context, accNum int, accAmt sdk.Int) []sdk.AccAddress {
-//	return addTestAddrs(app, ctx, accNum, accAmt, createIncrementalAccounts)
-//}
-
-//func addTestAddrs(app *TgradeApp, ctx sdk.Context, accNum int, accAmt sdk.Int, strategy GenerateAccountStrategy) []sdk.AccAddress {
-//	testAddrs := strategy(accNum)
-//
-//	initCoins := sdk.NewCoins(sdk.NewCoin(app.stakingKeeper.BondDenom(ctx), accAmt))
-//	setTotalSupply(app, ctx, accAmt, accNum)
-//
-//	// fill all the addresses with some coins, set the loose pool tokens simultaneously
-//	for _, addr := range testAddrs {
-//		saveAccount(app, ctx, addr, initCoins)
-//	}
-//
-//	return testAddrs
-//}
-
-// ConvertAddrsToValAddrs converts the provided addresses to ValAddress.
-func ConvertAddrsToValAddrs(addrs []sdk.AccAddress) []sdk.ValAddress {
-	valAddrs := make([]sdk.ValAddress, len(addrs))
-
-	for i, addr := range addrs {
-		valAddrs[i] = sdk.ValAddress(addr)
-	}
-
-	return valAddrs
 }
 
 func TestAddr(addr string, bech string) (sdk.AccAddress, error) {
@@ -397,8 +341,8 @@ func incrementAllSequenceNumbers(initSeqNums []uint64) {
 }
 
 // CreateTestPubKeys returns a total of numPubKeys public keys in ascending order.
-func CreateTestPubKeys(numPubKeys int) []cryptotypes.PubKey {
-	var publicKeys []cryptotypes.PubKey
+func CreateTestPubKeys(numPubKeys int) []cryptotypes.PubKey { //nolint:deadcode
+	var publicKeys []cryptotypes.PubKey //nolint:prealloc
 	var buffer bytes.Buffer
 
 	// start at 10 to avoid changing 1 to 01, 2 to 02, etc

--- a/cmd/tgrade/genaccounts.go
+++ b/cmd/tgrade/genaccounts.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/server"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -40,8 +39,7 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-			depCdc := clientCtx.Codec
-			cdc := depCdc.(codec.Codec)
+			cdc := clientCtx.Codec
 
 			serverCtx := server.GetServerContextFromCmd(cmd)
 			config := serverCtx.Config
@@ -52,7 +50,7 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 			addr, err := sdk.AccAddressFromBech32(args[0])
 			if err != nil {
 				inBuf := bufio.NewReader(cmd.InOrStdin())
-				keyringBackend, _ := cmd.Flags().GetString(flags.FlagKeyringBackend)
+				keyringBackend, _ := cmd.Flags().GetString(flags.FlagKeyringBackend) //nolint:errcheck
 				if keyringBackend != "" && clientCtx.Keyring == nil {
 					var err error
 					kr, err = keyring.New(sdk.KeyringServiceName(), keyringBackend, clientCtx.HomeDir, inBuf)
@@ -75,9 +73,9 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 				return fmt.Errorf("failed to parse coins: %w", err)
 			}
 
-			vestingStart, _ := cmd.Flags().GetInt64(flagVestingStart)
-			vestingEnd, _ := cmd.Flags().GetInt64(flagVestingEnd)
-			vestingAmtStr, _ := cmd.Flags().GetString(flagVestingAmt)
+			vestingStart, _ := cmd.Flags().GetInt64(flagVestingStart) //nolint:errcheck
+			vestingEnd, _ := cmd.Flags().GetInt64(flagVestingEnd)     //nolint:errcheck
+			vestingAmtStr, _ := cmd.Flags().GetString(flagVestingAmt) //nolint:errcheck
 
 			vestingAmt, err := sdk.ParseCoinsNormalized(vestingAmtStr)
 			if err != nil {

--- a/cmd/tgrade/root.go
+++ b/cmd/tgrade/root.go
@@ -131,7 +131,9 @@ func customizeInitCmdDefaults(initCmd *cobra.Command) *cobra.Command {
 		cfg := server.GetServerContextFromCmd(cmd)
 		// set a high default value to have a more resilient network but this also puts a higher strain on node memory
 		cfg.Config.P2P.MaxNumOutboundPeers = 200
-		server.SetCmdServerContext(cmd, cfg)
+		if err := server.SetCmdServerContext(cmd, cfg); err != nil {
+			panic(err)
+		}
 		return orig(initCmd, args)
 	}
 	return initCmd

--- a/testing/cli.go
+++ b/testing/cli.go
@@ -123,7 +123,7 @@ func (c TgradeCli) withTXFlags(args ...string) []string {
 }
 
 func (c TgradeCli) withKeyringFlags(args ...string) []string {
-	r := append(args,
+	r := append(args, //nolint:gocritic
 		"--home", c.homeDir,
 		"--keyring-backend", "test",
 	)

--- a/testing/node_utils.go
+++ b/testing/node_utils.go
@@ -11,12 +11,12 @@ import (
 )
 
 // load validator nodes consensus pub key for given node number
-func loadValidatorPubKeyForNode(t *testing.T, sut *SystemUnderTest, nodeNumber int) cryptotypes.PubKey {
+func loadValidatorPubKeyForNode(t *testing.T, sut *SystemUnderTest, nodeNumber int) cryptotypes.PubKey { //nolint:unused,deadcode
 	return loadValidatorPubKey(t, filepath.Join(workDir, sut.nodePath(nodeNumber), "config", "priv_validator_key.json"))
 }
 
 // load validator nodes consensus pub key from disk
-func loadValidatorPubKey(t *testing.T, keyFile string) cryptotypes.PubKey {
+func loadValidatorPubKey(t *testing.T, keyFile string) cryptotypes.PubKey { //nolint:unused,deadcode
 	filePV := privval.LoadFilePVEmptyState(keyFile, "")
 	pubKey, err := filePV.GetPubKey()
 	require.NoError(t, err)
@@ -26,7 +26,7 @@ func loadValidatorPubKey(t *testing.T, keyFile string) cryptotypes.PubKey {
 }
 
 // queryTendermintValidatorPower returns the validator's power from tendermint RPC endpoint. 0 when not found
-func queryTendermintValidatorPower(t *testing.T, sut *SystemUnderTest, nodeNumber int) int64 {
+func queryTendermintValidatorPower(t *testing.T, sut *SystemUnderTest, nodeNumber int) int64 { //nolint:unused,deadcode
 	pubKey := loadValidatorPubKeyForNode(t, sut, nodeNumber)
 	valResult := NewTgradeCli(t, sut, false).GetTendermintValidatorSet()
 	for _, v := range valResult.Validators {

--- a/testing/poe_test.go
+++ b/testing/poe_test.go
@@ -81,7 +81,7 @@ func TestProofOfEngagementSetup(t *testing.T) {
 	engagementUpdateMsg := poecontracts.UpdateMembersMsg{
 		Remove: []string{sortedMember[0].Addr},
 	}
-	eResult := cli.Execute(engagementGroupAddr, engagementUpdateMsg.Json(t), tg4BootstrapAccountAddr)
+	eResult := cli.Execute(engagementGroupAddr, engagementUpdateMsg.ToJSON(t), tg4BootstrapAccountAddr)
 	RequireTxSuccess(t, eResult)
 	t.Log("got execution result", eResult)
 	// wait for msg execution

--- a/x/globalfee/ante_test.go
+++ b/x/globalfee/ante_test.go
@@ -11,7 +11,6 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/log"
@@ -23,14 +22,14 @@ import (
 
 func TestGlobalMinimumChainFeeAnteHandler(t *testing.T) {
 	specs := map[string]struct {
-		setupStore func(ctx sdk.Context, s paramtypes.Subspace)
+		setupStore func(ctx sdk.Context, s paramstypes.Subspace)
 		next       sdk.AnteDecorator
 		feeAmount  sdk.Coins
 		gasLimit   sdk.Gas
 		expErr     *sdkerrors.Error
 	}{
 		"single fee above min": {
-			setupStore: func(ctx sdk.Context, s paramtypes.Subspace) {
+			setupStore: func(ctx sdk.Context, s paramstypes.Subspace) {
 				s.SetParamSet(ctx, &types.Params{
 					MinimumGasPrices: sdk.NewDecCoins(sdk.NewDecCoin("ALX", sdk.OneInt())),
 				})
@@ -39,7 +38,7 @@ func TestGlobalMinimumChainFeeAnteHandler(t *testing.T) {
 			gasLimit:  1,
 		},
 		"single fee below min": {
-			setupStore: func(ctx sdk.Context, s paramtypes.Subspace) {
+			setupStore: func(ctx sdk.Context, s paramstypes.Subspace) {
 				s.SetParamSet(ctx, &types.Params{
 					MinimumGasPrices: sdk.NewDecCoins(sdk.NewDecCoin("ALX", sdk.NewInt(2))),
 				})
@@ -49,7 +48,7 @@ func TestGlobalMinimumChainFeeAnteHandler(t *testing.T) {
 			expErr:    sdkerrors.ErrInsufficientFee,
 		},
 		"single fee equal min": {
-			setupStore: func(ctx sdk.Context, s paramtypes.Subspace) {
+			setupStore: func(ctx sdk.Context, s paramstypes.Subspace) {
 				s.SetParamSet(ctx, &types.Params{
 					MinimumGasPrices: sdk.NewDecCoins(sdk.NewDecCoin("ALX", sdk.OneInt())),
 				})
@@ -58,7 +57,7 @@ func TestGlobalMinimumChainFeeAnteHandler(t *testing.T) {
 			gasLimit:  1,
 		},
 		"multiple fees both above min": {
-			setupStore: func(ctx sdk.Context, s paramtypes.Subspace) {
+			setupStore: func(ctx sdk.Context, s paramstypes.Subspace) {
 				s.SetParamSet(ctx, &types.Params{
 					MinimumGasPrices: sdk.NewDecCoins(sdk.NewDecCoin("ALX", sdk.OneInt()), sdk.NewDecCoin("BLX", sdk.OneInt())),
 				})
@@ -67,7 +66,7 @@ func TestGlobalMinimumChainFeeAnteHandler(t *testing.T) {
 			gasLimit:  1,
 		},
 		"multiple fees both below min": {
-			setupStore: func(ctx sdk.Context, s paramtypes.Subspace) {
+			setupStore: func(ctx sdk.Context, s paramstypes.Subspace) {
 				s.SetParamSet(ctx, &types.Params{
 					MinimumGasPrices: sdk.NewDecCoins(sdk.NewDecCoin("ALX", sdk.NewInt(2)), sdk.NewDecCoin("BLX", sdk.NewInt(2))),
 				})
@@ -77,7 +76,7 @@ func TestGlobalMinimumChainFeeAnteHandler(t *testing.T) {
 			expErr:    sdkerrors.ErrInsufficientFee,
 		},
 		"multiple fees both equal min": {
-			setupStore: func(ctx sdk.Context, s paramtypes.Subspace) {
+			setupStore: func(ctx sdk.Context, s paramstypes.Subspace) {
 				s.SetParamSet(ctx, &types.Params{
 					MinimumGasPrices: sdk.NewDecCoins(sdk.NewDecCoin("ALX", sdk.OneInt()), sdk.NewDecCoin("BLX", sdk.OneInt())),
 				})
@@ -86,7 +85,7 @@ func TestGlobalMinimumChainFeeAnteHandler(t *testing.T) {
 			gasLimit:  1,
 		},
 		"multiple fees one below min": {
-			setupStore: func(ctx sdk.Context, s paramtypes.Subspace) {
+			setupStore: func(ctx sdk.Context, s paramstypes.Subspace) {
 				s.SetParamSet(ctx, &types.Params{
 					MinimumGasPrices: sdk.NewDecCoins(sdk.NewDecCoin("ALX", sdk.NewInt(2)), sdk.NewDecCoin("BLX", sdk.NewInt(2))),
 				})
@@ -95,7 +94,7 @@ func TestGlobalMinimumChainFeeAnteHandler(t *testing.T) {
 			gasLimit:  1,
 		},
 		"multiple fees one equal min": {
-			setupStore: func(ctx sdk.Context, s paramtypes.Subspace) {
+			setupStore: func(ctx sdk.Context, s paramstypes.Subspace) {
 				s.SetParamSet(ctx, &types.Params{
 					MinimumGasPrices: sdk.NewDecCoins(sdk.NewDecCoin("ALX", sdk.NewInt(2)), sdk.NewDecCoin("BLX", sdk.NewInt(2))),
 				})
@@ -104,7 +103,7 @@ func TestGlobalMinimumChainFeeAnteHandler(t *testing.T) {
 			gasLimit:  1,
 		},
 		"multiple fees one submitted": {
-			setupStore: func(ctx sdk.Context, s paramtypes.Subspace) {
+			setupStore: func(ctx sdk.Context, s paramstypes.Subspace) {
 				s.SetParamSet(ctx, &types.Params{
 					MinimumGasPrices: sdk.NewDecCoins(sdk.NewDecCoin("ALX", sdk.OneInt()), sdk.NewDecCoin("BLX", sdk.OneInt())),
 				})
@@ -113,7 +112,7 @@ func TestGlobalMinimumChainFeeAnteHandler(t *testing.T) {
 			gasLimit:  1,
 		},
 		"multiple fees with non fee token added": {
-			setupStore: func(ctx sdk.Context, s paramtypes.Subspace) {
+			setupStore: func(ctx sdk.Context, s paramstypes.Subspace) {
 				s.SetParamSet(ctx, &types.Params{
 					MinimumGasPrices: sdk.NewDecCoins(sdk.NewDecCoin("ALX", sdk.OneInt()), sdk.NewDecCoin("BLX", sdk.OneInt())),
 				})
@@ -122,7 +121,7 @@ func TestGlobalMinimumChainFeeAnteHandler(t *testing.T) {
 			gasLimit:  1,
 		},
 		"multiple fees with only non fee token": {
-			setupStore: func(ctx sdk.Context, s paramtypes.Subspace) {
+			setupStore: func(ctx sdk.Context, s paramstypes.Subspace) {
 				s.SetParamSet(ctx, &types.Params{
 					MinimumGasPrices: sdk.NewDecCoins(sdk.NewDecCoin("ALX", sdk.OneInt()), sdk.NewDecCoin("BLX", sdk.OneInt())),
 				})
@@ -132,18 +131,18 @@ func TestGlobalMinimumChainFeeAnteHandler(t *testing.T) {
 			expErr:    sdkerrors.ErrInsufficientFee,
 		},
 		"no min gas price set": {
-			setupStore: func(ctx sdk.Context, s paramtypes.Subspace) {
+			setupStore: func(ctx sdk.Context, s paramstypes.Subspace) {
 				s.SetParamSet(ctx, &types.Params{})
 			},
 			gasLimit: 1,
 		},
 		"no param set": {
-			setupStore: func(ctx sdk.Context, s paramtypes.Subspace) {
+			setupStore: func(ctx sdk.Context, s paramstypes.Subspace) {
 			},
 			gasLimit: 1,
 		},
 		"no gas set": {
-			setupStore: func(ctx sdk.Context, s paramtypes.Subspace) {
+			setupStore: func(ctx sdk.Context, s paramstypes.Subspace) {
 				s.SetParamSet(ctx, &types.Params{
 					MinimumGasPrices: sdk.NewDecCoins(sdk.NewDecCoin("ALX", sdk.OneInt())),
 				})
@@ -152,7 +151,7 @@ func TestGlobalMinimumChainFeeAnteHandler(t *testing.T) {
 			expErr:    sdkerrors.ErrInsufficientFee, // error message is a bit odd: "got: 2ALX required: 0ALX: insufficient fee"
 		},
 		"no fee set": {
-			setupStore: func(ctx sdk.Context, s paramtypes.Subspace) {
+			setupStore: func(ctx sdk.Context, s paramstypes.Subspace) {
 				s.SetParamSet(ctx, &types.Params{
 					MinimumGasPrices: sdk.NewDecCoins(sdk.NewDecCoin("ALX", sdk.OneInt())),
 				})
@@ -186,7 +185,7 @@ func TestGlobalMinimumChainFeeAnteHandler(t *testing.T) {
 	}
 }
 
-func setupTestStore(t *testing.T) (sdk.Context, simappparams.EncodingConfig, paramtypes.Subspace) {
+func setupTestStore(t *testing.T) (sdk.Context, simappparams.EncodingConfig, paramstypes.Subspace) {
 	db := dbm.NewMemDB()
 	ms := store.NewCommitMultiStore(db)
 	encCfg := simapp.MakeTestEncodingConfig()

--- a/x/globalfee/client/cli/query.go
+++ b/x/globalfee/client/cli/query.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"fmt"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
@@ -28,7 +26,7 @@ func GetCmdShowMinimumGasPrices() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "minimum-gas-prices",
 		Short:   "Show minimum gas prices",
-		Long:    fmt.Sprintf("Show all minimum gas prices"),
+		Long:    "Show all minimum gas prices",
 		Aliases: []string{"min"},
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/x/globalfee/genesis_test.go
+++ b/x/globalfee/genesis_test.go
@@ -81,10 +81,10 @@ func TestInitExportGenesis(t *testing.T) {
 			ctx, encCfg, subspace := setupTestStore(t)
 			m := NewAppModule(subspace)
 			m.InitGenesis(ctx, encCfg.Marshaler, []byte(spec.src))
-			gotJson := m.ExportGenesis(ctx, encCfg.Marshaler)
+			gotJSON := m.ExportGenesis(ctx, encCfg.Marshaler)
 			var got types.GenesisState
-			require.NoError(t, encCfg.Marshaler.UnmarshalJSON(gotJson, &got))
-			assert.Equal(t, spec.exp, got, string(gotJson))
+			require.NoError(t, encCfg.Marshaler.UnmarshalJSON(gotJSON, &got))
+			assert.Equal(t, spec.exp, got, string(gotJSON))
 		})
 	}
 }

--- a/x/globalfee/module.go
+++ b/x/globalfee/module.go
@@ -60,7 +60,9 @@ func (a AppModuleBasic) RegisterRESTRoutes(context client.Context, router *mux.R
 }
 
 func (a AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
-	_ = types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
+	if err := types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)); err != nil {
+		panic(err)
+	}
 }
 
 func (a AppModuleBasic) GetTxCmd() *cobra.Command {
@@ -117,7 +119,7 @@ func (a AppModule) LegacyQuerierHandler(amino *codec.LegacyAmino) sdk.Querier {
 }
 
 func (a AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterQueryServer(cfg.QueryServer(), NewGrpcQuerier(a.paramSpace))
+	types.RegisterQueryServer(cfg.QueryServer(), NewQuerier(a.paramSpace))
 }
 
 func (a AppModule) BeginBlock(context sdk.Context, block abci.RequestBeginBlock) {
@@ -131,7 +133,7 @@ func (a AppModule) EndBlock(context sdk.Context, block abci.RequestEndBlock) []a
 // module. It should be incremented on each consensus-breaking change
 // introduced by the module. To avoid wrong/empty versions, the initial version
 // should be set to 1.
-func (am AppModule) ConsensusVersion() uint64 {
+func (a AppModule) ConsensusVersion() uint64 {
 	return 1
 }
 

--- a/x/globalfee/querier.go
+++ b/x/globalfee/querier.go
@@ -8,18 +8,18 @@ import (
 	"github.com/confio/tgrade/x/globalfee/types"
 )
 
-var _ types.QueryServer = &grpcQuerier{}
+var _ types.QueryServer = &Querier{}
 
-type grpcQuerier struct {
+type Querier struct {
 	paramSource paramSource
 }
 
-func NewGrpcQuerier(paramSource paramSource) grpcQuerier {
-	return grpcQuerier{paramSource: paramSource}
+func NewQuerier(paramSource paramSource) Querier {
+	return Querier{paramSource: paramSource}
 }
 
 // MinimumGasPrices return minimum gas prices
-func (g grpcQuerier) MinimumGasPrices(stdCtx context.Context, _ *types.QueryMinimumGasPricesRequest) (*types.QueryMinimumGasPricesResponse, error) {
+func (g Querier) MinimumGasPrices(stdCtx context.Context, _ *types.QueryMinimumGasPricesRequest) (*types.QueryMinimumGasPricesResponse, error) {
 	var minGasPrices sdk.DecCoins
 	ctx := sdk.UnwrapSDKContext(stdCtx)
 	if g.paramSource.Has(ctx, types.ParamStoreKeyMinGasPrices) {

--- a/x/globalfee/querier_test.go
+++ b/x/globalfee/querier_test.go
@@ -46,7 +46,7 @@ func TestQueryMinimumGasPrices(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx, _, subspace := setupTestStore(t)
 			spec.setupStore(ctx, subspace)
-			q := NewGrpcQuerier(subspace)
+			q := NewQuerier(subspace)
 			gotResp, gotErr := q.MinimumGasPrices(sdk.WrapSDKContext(ctx), nil)
 			require.NoError(t, gotErr)
 			require.NotNil(t, gotResp)

--- a/x/globalfee/types/params.go
+++ b/x/globalfee/types/params.go
@@ -4,7 +4,6 @@ import (
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/cosmos/cosmos-sdk/x/params/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
@@ -16,8 +15,8 @@ func DefaultParams() Params {
 	return Params{MinimumGasPrices: sdk.DecCoins{}}
 }
 
-func ParamKeyTable() types.KeyTable {
-	return types.NewKeyTable().RegisterParamSet(&Params{})
+func ParamKeyTable() paramtypes.KeyTable {
+	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
 }
 
 // ValidateBasic performs basic validation.
@@ -28,7 +27,7 @@ func (p Params) ValidateBasic() error {
 // ParamSetPairs returns the parameter set pairs.
 func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	return paramtypes.ParamSetPairs{
-		types.NewParamSetPair(
+		paramtypes.NewParamSetPair(
 			ParamStoreKeyMinGasPrices, &p.MinimumGasPrices, validateMinimumGasPrices,
 		),
 	}

--- a/x/poe/bootstrap.go
+++ b/x/poe/bootstrap.go
@@ -36,7 +36,7 @@ var (
 	//go:embed contract/tgrade_ap_voting.wasm
 	tgArbiterPool []byte
 	//go:embed contract/version.txt
-	contractVersion []byte
+	contractVersion string
 )
 
 // ClearEmbeddedContracts release memory
@@ -298,7 +298,7 @@ func BootstrapPoEContracts(ctx sdk.Context, k wasmtypes.ContractOpsKeeper, tk tw
 	if err := setAllPoEContractsInstanceMigrators(ctx, k, poeKeeper, bootstrapAccountAddr, validatorVotingContractAddr); err != nil {
 		return sdkerrors.Wrap(err, "set new instance admin")
 	}
-
+	keeper.ModuleLogger(ctx).Info("Seeded PoE contracts", "version", contractVersion)
 	return nil
 }
 

--- a/x/poe/bootstrap.go
+++ b/x/poe/bootstrap.go
@@ -74,7 +74,7 @@ func BootstrapPoEContracts(ctx sdk.Context, k wasmtypes.ContractOpsKeeper, tk tw
 	if err != nil {
 		return sdkerrors.Wrap(err, "store tg4 engagement contract")
 	}
-	engagementContractAddr, _, err := k.Instantiate(ctx, engagementCodeID, bootstrapAccountAddr, bootstrapAccountAddr, mustMarshalJson(tg4EngagementInitMsg), "engagement", nil)
+	engagementContractAddr, _, err := k.Instantiate(ctx, engagementCodeID, bootstrapAccountAddr, bootstrapAccountAddr, mustMarshalJSON(tg4EngagementInitMsg), "engagement", nil)
 	if err != nil {
 		return sdkerrors.Wrap(err, "instantiate tg4 engagement")
 	}
@@ -99,7 +99,7 @@ func BootstrapPoEContracts(ctx sdk.Context, k wasmtypes.ContractOpsKeeper, tk tw
 		return sdkerrors.Wrap(err, "first member")
 	}
 
-	ocContractAddr, _, err := k.Instantiate(ctx, trustedCircleCodeID, firstOCMember, bootstrapAccountAddr, mustMarshalJson(ocInitMsg), "oversight_committee", ocDeposit)
+	ocContractAddr, _, err := k.Instantiate(ctx, trustedCircleCodeID, firstOCMember, bootstrapAccountAddr, mustMarshalJSON(ocInitMsg), "oversight_committee", ocDeposit)
 	if err != nil {
 		return sdkerrors.Wrap(err, "instantiate tg trusted circle contract")
 	}
@@ -124,7 +124,7 @@ func BootstrapPoEContracts(ctx sdk.Context, k wasmtypes.ContractOpsKeeper, tk tw
 		return sdkerrors.Wrap(err, "store tg4 stake contract")
 	}
 	tg4StakeInitMsg := newStakeInitMsg(gs, bootstrapAccountAddr)
-	stakeContractAddr, _, err := k.Instantiate(ctx, stakeCodeID, bootstrapAccountAddr, bootstrapAccountAddr, mustMarshalJson(tg4StakeInitMsg), "stakers", nil)
+	stakeContractAddr, _, err := k.Instantiate(ctx, stakeCodeID, bootstrapAccountAddr, bootstrapAccountAddr, mustMarshalJSON(tg4StakeInitMsg), "stakers", nil)
 	if err != nil {
 		return sdkerrors.Wrap(err, "instantiate tg4 stake")
 	}
@@ -148,7 +148,7 @@ func BootstrapPoEContracts(ctx sdk.Context, k wasmtypes.ContractOpsKeeper, tk tw
 	if err != nil {
 		return sdkerrors.Wrap(err, "store tg4 mixer contract")
 	}
-	mixerContractAddr, _, err := k.Instantiate(ctx, mixerCodeID, bootstrapAccountAddr, bootstrapAccountAddr, mustMarshalJson(tg4MixerInitMsg), "poe", nil)
+	mixerContractAddr, _, err := k.Instantiate(ctx, mixerCodeID, bootstrapAccountAddr, bootstrapAccountAddr, mustMarshalJSON(tg4MixerInitMsg), "poe", nil)
 	if err != nil {
 		return sdkerrors.Wrap(err, "instantiate tg4 mixer")
 	}
@@ -168,7 +168,7 @@ func BootstrapPoEContracts(ctx sdk.Context, k wasmtypes.ContractOpsKeeper, tk tw
 		VotingRules:  toContractVotingRules(gs.CommunityPoolContractConfig.VotingRules),
 		GroupAddress: engagementContractAddr.String(),
 	}
-	communityPoolContractAddr, _, err := k.Instantiate(ctx, communityPoolCodeID, bootstrapAccountAddr, bootstrapAccountAddr, mustMarshalJson(communityPoolInitMsg), "stakers", nil)
+	communityPoolContractAddr, _, err := k.Instantiate(ctx, communityPoolCodeID, bootstrapAccountAddr, bootstrapAccountAddr, mustMarshalJSON(communityPoolInitMsg), "stakers", nil)
 	if err != nil {
 		return sdkerrors.Wrap(err, "instantiate community pool")
 	}
@@ -186,7 +186,7 @@ func BootstrapPoEContracts(ctx sdk.Context, k wasmtypes.ContractOpsKeeper, tk tw
 	}
 
 	valsetInitMsg := newValsetInitMsg(gs, bootstrapAccountAddr, mixerContractAddr, engagementContractAddr, communityPoolContractAddr, engagementCodeID)
-	valsetJSON := mustMarshalJson(valsetInitMsg)
+	valsetJSON := mustMarshalJSON(valsetInitMsg)
 	valsetContractAddr, _, err := k.Instantiate(ctx, valSetCodeID, bootstrapAccountAddr, bootstrapAccountAddr, valsetJSON, "valset", nil)
 	if err != nil {
 		return sdkerrors.Wrapf(err, "instantiate valset with: %s", string(valsetJSON))
@@ -218,7 +218,7 @@ func BootstrapPoEContracts(ctx sdk.Context, k wasmtypes.ContractOpsKeeper, tk tw
 		return sdkerrors.Wrap(err, "store tg oc gov proposals contract: ")
 	}
 	ocGovInitMsg := newOCGovProposalsInitMsg(gs, ocContractAddr, engagementContractAddr, valsetContractAddr)
-	ocGovProposalsContractAddr, _, err := k.Instantiate(ctx, ocGovCodeID, bootstrapAccountAddr, bootstrapAccountAddr, mustMarshalJson(ocGovInitMsg), "oversight_committee gov proposals", ocDeposit)
+	ocGovProposalsContractAddr, _, err := k.Instantiate(ctx, ocGovCodeID, bootstrapAccountAddr, bootstrapAccountAddr, mustMarshalJSON(ocGovInitMsg), "oversight_committee gov proposals", ocDeposit)
 	if err != nil {
 		return sdkerrors.Wrap(err, "instantiate tg oc gov proposals contract")
 	}
@@ -248,7 +248,7 @@ func BootstrapPoEContracts(ctx sdk.Context, k wasmtypes.ContractOpsKeeper, tk tw
 		VotingRules:  toContractVotingRules(gs.ValidatorVotingContractConfig.VotingRules),
 		GroupAddress: distrAddr.String(),
 	}
-	validatorVotingContractAddr, _, err := k.Instantiate(ctx, validatorVotingCodeID, bootstrapAccountAddr, bootstrapAccountAddr, mustMarshalJson(validatorVotingInitMsg), "stakers", nil)
+	validatorVotingContractAddr, _, err := k.Instantiate(ctx, validatorVotingCodeID, bootstrapAccountAddr, bootstrapAccountAddr, mustMarshalJSON(validatorVotingInitMsg), "stakers", nil)
 	if err != nil {
 		return sdkerrors.Wrap(err, "instantiate validator voting")
 	}
@@ -267,7 +267,7 @@ func BootstrapPoEContracts(ctx sdk.Context, k wasmtypes.ContractOpsKeeper, tk tw
 		return sdkerrors.Wrap(err, "first ap member")
 	}
 
-	apContractAddr, _, err := k.Instantiate(ctx, trustedCircleCodeID, firstAPMember, bootstrapAccountAddr, mustMarshalJson(apTrustedCircleInitMsg), "arbiter_pool", apDeposit)
+	apContractAddr, _, err := k.Instantiate(ctx, trustedCircleCodeID, firstAPMember, bootstrapAccountAddr, mustMarshalJSON(apTrustedCircleInitMsg), "arbiter_pool", apDeposit)
 	if err != nil {
 		return sdkerrors.Wrap(err, "instantiate tg trusted circle contract")
 	}
@@ -285,7 +285,7 @@ func BootstrapPoEContracts(ctx sdk.Context, k wasmtypes.ContractOpsKeeper, tk tw
 		return sdkerrors.Wrap(err, "store arbiter voting contract: ")
 	}
 	apVotingInitMsg := newArbiterPoolVotingInitMsg(gs, apContractAddr)
-	apVotingContractAddr, _, err := k.Instantiate(ctx, apCodeID, bootstrapAccountAddr, bootstrapAccountAddr, mustMarshalJson(apVotingInitMsg), "arbiter pool voting", apDeposit)
+	apVotingContractAddr, _, err := k.Instantiate(ctx, apCodeID, bootstrapAccountAddr, bootstrapAccountAddr, mustMarshalJSON(apVotingInitMsg), "arbiter pool voting", apDeposit)
 	if err != nil {
 		return sdkerrors.Wrap(err, "instantiate tg ap voting contract")
 	}
@@ -302,7 +302,7 @@ func BootstrapPoEContracts(ctx sdk.Context, k wasmtypes.ContractOpsKeeper, tk tw
 	return nil
 }
 
-func addToTrustedCircle(ctx sdk.Context, contractAddr sdk.AccAddress, tk twasmKeeper, members []string, sender sdk.AccAddress, deposit sdk.Coin) error {
+func addToTrustedCircle(ctx sdk.Context, contractAddr sdk.AccAddress, tk types.TWasmKeeper, members []string, sender sdk.AccAddress, deposit sdk.Coin) error {
 	tcAdapter := contract.NewTrustedCircleContractAdapter(contractAddr, tk, nil)
 	err := tcAdapter.AddVotingMembersProposal(ctx, members, sender)
 	if err != nil {
@@ -331,7 +331,7 @@ func addToTrustedCircle(ctx sdk.Context, contractAddr sdk.AccAddress, tk twasmKe
 }
 
 // set new migrator for all PoE contracts
-func setAllPoEContractsInstanceMigrators(ctx sdk.Context, k wasmtypes.ContractOpsKeeper, poeKeeper poeKeeper, oldAdminAddr, newAdminAddr sdk.AccAddress) error {
+func setAllPoEContractsInstanceMigrators(ctx sdk.Context, k wasmtypes.ContractOpsKeeper, poeKeeper keeper.ContractSource, oldAdminAddr, newAdminAddr sdk.AccAddress) error {
 	var rspErr error
 	types.IteratePoEContractTypes(func(tp types.PoEContractType) bool {
 		addr, err := poeKeeper.GetPoEContractAddress(ctx, tp)
@@ -465,8 +465,8 @@ func newValsetInitMsg(
 	}
 }
 
-// VerifyPoEContracts sanity check that verifies all PoE contracts are setup as expected
-func VerifyPoEContracts(ctx sdk.Context, tk twasmKeeper, poeKeeper poeKeeper) error {
+// VerifyPoEContracts sanity check that verifies all PoE contracts are set up as expected
+func VerifyPoEContracts(ctx sdk.Context, tk twasmKeeper, poeKeeper keeper.ContractSource) error {
 	valVotingContractAddr, err := poeKeeper.GetPoEContractAddress(ctx, types.PoEContractTypeValidatorVoting)
 	if err != nil {
 		return sdkerrors.Wrap(err, "validator voting address")
@@ -523,8 +523,8 @@ func VerifyPoEContracts(ctx sdk.Context, tk twasmKeeper, poeKeeper poeKeeper) er
 	return nil
 }
 
-// mustMarshalJson with stdlib json
-func mustMarshalJson(s interface{}) []byte {
+// mustMarshalJSON with stdlib json
+func mustMarshalJSON(s interface{}) []byte {
 	jsonBz, err := json.Marshal(s)
 	if err != nil {
 		panic(fmt.Sprintf("failed to marshal json: %s", err))

--- a/x/poe/bootstrap_integration_test.go
+++ b/x/poe/bootstrap_integration_test.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"testing"
 
+	twasmkeeper "github.com/confio/tgrade/x/twasm/keeper"
+
 	"github.com/cosmos/cosmos-sdk/types/address"
 	"github.com/tendermint/tendermint/libs/rand"
 
@@ -123,48 +125,47 @@ func TestIntegrationBootstrapPoEContracts(t *testing.T) {
 
 func TestVerifyPoEContracts(t *testing.T) {
 	// setup contracts and seed some data
-	parentCtx, example, _ := setupPoEContracts(t)
 	specs := map[string]struct {
-		alterState func(t *testing.T, ctx sdk.Context)
+		alterState func(t *testing.T, ctx sdk.Context, poeKeeper *keeper.Keeper, twasmKeeper *twasmkeeper.Keeper)
 		expErr     bool
 	}{
 		"all good": {
-			alterState: func(t *testing.T, ctx sdk.Context) {}, //  noop
+			alterState: func(t *testing.T, ctx sdk.Context, poeKeeper *keeper.Keeper, twasmKeeper *twasmkeeper.Keeper) {}, //  noop
 		},
 		"poe contract not pinned": {
-			alterState: func(t *testing.T, ctx sdk.Context) {
-				require.NoError(t, example.TWasmKeeper.GetContractKeeper().UnpinCode(ctx, 1))
+			alterState: func(t *testing.T, ctx sdk.Context, poeKeeper *keeper.Keeper, twasmKeeper *twasmkeeper.Keeper) {
+				require.NoError(t, twasmKeeper.GetContractKeeper().UnpinCode(ctx, 1))
 			},
 			expErr: true,
 		},
 		"poe contract without correct migrator": {
-			alterState: func(t *testing.T, ctx sdk.Context) {
-				contractAddr, _ := example.PoEKeeper.GetPoEContractAddress(ctx, types.PoEContractTypeStaking)
-				valVotingAddr, _ := example.PoEKeeper.GetPoEContractAddress(ctx, types.PoEContractTypeValidatorVoting)
+			alterState: func(t *testing.T, ctx sdk.Context, poeKeeper *keeper.Keeper, twasmKeeper *twasmkeeper.Keeper) {
+				contractAddr, _ := poeKeeper.GetPoEContractAddress(ctx, types.PoEContractTypeStaking)
+				valVotingAddr, _ := poeKeeper.GetPoEContractAddress(ctx, types.PoEContractTypeValidatorVoting)
 				otherAddr := rand.Bytes(address.Len)
-				require.NoError(t, example.TWasmKeeper.GetContractKeeper().UpdateContractAdmin(ctx, contractAddr, valVotingAddr, otherAddr))
+				require.NoError(t, twasmKeeper.GetContractKeeper().UpdateContractAdmin(ctx, contractAddr, valVotingAddr, otherAddr))
 			},
 			expErr: true,
 		},
 		"without validator update privilege set": {
-			alterState: func(t *testing.T, ctx sdk.Context) {
-				otherContract, _ := example.PoEKeeper.GetPoEContractAddress(ctx, types.PoEContractTypeEngagement)
-				example.PoEKeeper.SetPoEContractAddress(ctx, types.PoEContractTypeValset, otherContract)
+			alterState: func(t *testing.T, ctx sdk.Context, poeKeeper *keeper.Keeper, twasmKeeper *twasmkeeper.Keeper) {
+				otherContract, _ := poeKeeper.GetPoEContractAddress(ctx, types.PoEContractTypeEngagement)
+				poeKeeper.SetPoEContractAddress(ctx, types.PoEContractTypeValset, otherContract)
 			},
 			expErr: true,
 		},
 		"without delegator privilege set": {
-			alterState: func(t *testing.T, ctx sdk.Context) {
-				otherContract, _ := example.PoEKeeper.GetPoEContractAddress(ctx, types.PoEContractTypeEngagement)
-				example.PoEKeeper.SetPoEContractAddress(ctx, types.PoEContractTypeStaking, otherContract)
+			alterState: func(t *testing.T, ctx sdk.Context, poeKeeper *keeper.Keeper, twasmKeeper *twasmkeeper.Keeper) {
+				otherContract, _ := poeKeeper.GetPoEContractAddress(ctx, types.PoEContractTypeEngagement)
+				poeKeeper.SetPoEContractAddress(ctx, types.PoEContractTypeStaking, otherContract)
 			},
 			expErr: true,
 		},
 	}
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
-			ctx, _ := parentCtx.CacheContext()
-			spec.alterState(t, ctx)
+			ctx, example, _ := setupPoEContracts(t)
+			spec.alterState(t, ctx, example.PoEKeeper, example.TWasmKeeper)
 
 			gotErr := poe.VerifyPoEContracts(ctx, example.TWasmKeeper, example.PoEKeeper)
 			if spec.expErr {
@@ -176,7 +177,7 @@ func TestVerifyPoEContracts(t *testing.T) {
 	}
 }
 
-func setupPoEContracts(t *testing.T, mutators ...func(m *types.GenesisState)) (sdk.Context, keeper.TestKeepers, types.GenesisState) {
+func setupPoEContracts(t *testing.T, mutators ...func(m *types.GenesisState)) (sdk.Context, *keeper.TestKeepers, types.GenesisState) {
 	t.Helper()
 	ctx, example := keeper.CreateDefaultTestInput(t)
 	deliverTXFn := unAuthorizedDeliverTXFn(t, ctx, example.PoEKeeper, example.TWasmKeeper.GetContractKeeper(), example.EncodingConfig.TxConfig.TxDecoder())
@@ -200,7 +201,7 @@ func setupPoEContracts(t *testing.T, mutators ...func(m *types.GenesisState)) (s
 
 	genesisBz := example.EncodingConfig.Marshaler.MustMarshalJSON(gs)
 	module.InitGenesis(ctx, example.EncodingConfig.Marshaler, genesisBz)
-	return ctx, example, *gs
+	return ctx, &example, *gs
 }
 
 // unAuthorizedDeliverTXFn applies the TX without ante handler checks for testing purpose

--- a/x/poe/bootstrap_integration_test.go
+++ b/x/poe/bootstrap_integration_test.go
@@ -180,7 +180,7 @@ func setupPoEContracts(t *testing.T, mutators ...func(m *types.GenesisState)) (s
 	t.Helper()
 	ctx, example := keeper.CreateDefaultTestInput(t)
 	deliverTXFn := unAuthorizedDeliverTXFn(t, ctx, example.PoEKeeper, example.TWasmKeeper.GetContractKeeper(), example.EncodingConfig.TxConfig.TxDecoder())
-	module := poe.NewAppModule(&example.PoEKeeper, example.TWasmKeeper, example.BankKeeper, example.AccountKeeper, deliverTXFn, example.EncodingConfig.TxConfig, example.TWasmKeeper.GetContractKeeper())
+	module := poe.NewAppModule(example.PoEKeeper, example.TWasmKeeper, example.BankKeeper, example.AccountKeeper, deliverTXFn, example.EncodingConfig.TxConfig, example.TWasmKeeper.GetContractKeeper())
 
 	mutator, _ := withRandomValidators(t, ctx, example, 3)
 	gs := types.GenesisStateFixture(append([]func(m *types.GenesisState){mutator}, mutators...)...)
@@ -204,7 +204,7 @@ func setupPoEContracts(t *testing.T, mutators ...func(m *types.GenesisState)) (s
 }
 
 // unAuthorizedDeliverTXFn applies the TX without ante handler checks for testing purpose
-func unAuthorizedDeliverTXFn(t *testing.T, ctx sdk.Context, k keeper.Keeper, contractKeeper wasmtypes.ContractOpsKeeper, txDecoder sdk.TxDecoder) func(tx abci.RequestDeliverTx) abci.ResponseDeliverTx {
+func unAuthorizedDeliverTXFn(t *testing.T, ctx sdk.Context, k *keeper.Keeper, contractKeeper wasmtypes.ContractOpsKeeper, txDecoder sdk.TxDecoder) func(tx abci.RequestDeliverTx) abci.ResponseDeliverTx {
 	t.Helper()
 	h := poe.NewHandler(k, contractKeeper, nil)
 	return func(tx abci.RequestDeliverTx) abci.ResponseDeliverTx {

--- a/x/poe/client/cli/genutil_collect.go
+++ b/x/poe/client/cli/genutil_collect.go
@@ -47,7 +47,11 @@ func CollectGenTxsCmd(genBalIterator types.GenesisBalancesIterator, defaultNodeH
 				return errors.Wrap(err, "failed to read genesis doc from file")
 			}
 
-			genTxDir, _ := cmd.Flags().GetString(flagGenTxDir)
+			genTxDir, err := cmd.Flags().GetString(flagGenTxDir)
+			if err != nil {
+				return errors.Wrapf(err, "failed to read %q flag", flagGenTxDir)
+			}
+
 			genTxsDir := genTxDir
 			if genTxsDir == "" {
 				genTxsDir = filepath.Join(config.RootDir, "config", "gentx")

--- a/x/poe/client/cli/genutil_gentx.go
+++ b/x/poe/client/cli/genutil_gentx.go
@@ -35,7 +35,10 @@ type GenesisBalancesIterator = genutiltypes.GenesisBalancesIterator
 
 // GenTxCmd builds the application's gentx command.
 func GenTxCmd(mbm module.BasicManager, txEncCfg client.TxEncodingConfig, genBalIterator GenesisBalancesIterator, defaultNodeHome string) *cobra.Command {
-	ipDefault, _ := server.ExternalIP()
+	ipDefault, err := server.ExternalIP()
+	if err != nil {
+		panic(err)
+	}
 	fsCreateValidator, defaultsDesc := CreateValidatorMsgFlagSet(ipDefault)
 
 	cmd := &cobra.Command{
@@ -73,12 +76,12 @@ $ %s gentx my-key-name 1000000utgd --home=/path/to/home/dir --keyring-backend=os
 			}
 
 			// read --nodeID, if empty take it from priv_validator.json
-			if nodeIDString, _ := cmd.Flags().GetString(FlagNodeID); nodeIDString != "" {
+			if nodeIDString, _ := cmd.Flags().GetString(FlagNodeID); nodeIDString != "" { //nolint:errcheck
 				nodeID = nodeIDString
 			}
 
 			// read --pubkey, if empty take it from priv_validator.json
-			if pkStr, _ := cmd.Flags().GetString(FlagPubKey); pkStr != "" {
+			if pkStr, _ := cmd.Flags().GetString(FlagPubKey); pkStr != "" { //nolint:errcheck
 				if err := clientCtx.Codec.UnmarshalInterfaceJSON([]byte(pkStr), &valPubKey); err != nil {
 					return errors.Wrap(err, "failed to unmarshal validator public key")
 				}
@@ -107,7 +110,7 @@ $ %s gentx my-key-name 1000000utgd --home=/path/to/home/dir --keyring-backend=os
 			}
 
 			moniker := config.Moniker
-			if m, _ := cmd.Flags().GetString(FlagMoniker); m != "" {
+			if m, _ := cmd.Flags().GetString(FlagMoniker); m != "" { //nolint:errcheck
 				moniker = m
 			}
 
@@ -196,7 +199,7 @@ $ %s gentx my-key-name 1000000utgd --home=/path/to/home/dir --keyring-backend=os
 				return errors.Wrap(err, "failed to sign std tx")
 			}
 
-			outputDocument, _ := cmd.Flags().GetString(flags.FlagOutputDocument)
+			outputDocument, _ := cmd.Flags().GetString(flags.FlagOutputDocument) //nolint:errcheck
 			if outputDocument == "" {
 				outputDocument, err = makeOutputFilepath(config.RootDir, nodeID)
 				if err != nil {

--- a/x/poe/client/cli/tx.go
+++ b/x/poe/client/cli/tx.go
@@ -98,12 +98,11 @@ $ tgrade tx poe create-validator \
 	cmd.Flags().String(FlagNodeID, "", "The node's ID")
 	flags.AddTxFlagsToCmd(cmd)
 
-	_ = cmd.MarkFlagRequired(flags.FlagFrom)
-	_ = cmd.MarkFlagRequired(FlagAmount)
-	_ = cmd.MarkFlagRequired(FlagVestingAmount)
-	_ = cmd.MarkFlagRequired(FlagPubKey)
-	_ = cmd.MarkFlagRequired(FlagMoniker)
-
+	for _, v := range []string{flags.FlagFrom, FlagAmount, FlagVestingAmount, FlagPubKey, FlagMoniker} {
+		if err := cmd.MarkFlagRequired(v); err != nil {
+			panic(fmt.Sprintf("mark %q flag require: %s", v, err))
+		}
+	}
 	return cmd
 }
 
@@ -137,11 +136,11 @@ func NewBuildCreateValidatorMsg(clientCtx client.Context, txf tx.Factory, fs *fl
 		return txf, nil, err
 	}
 
-	moniker, _ := fs.GetString(FlagMoniker)
-	identity, _ := fs.GetString(FlagIdentity)
-	website, _ := fs.GetString(FlagWebsite)
-	security, _ := fs.GetString(FlagSecurityContact)
-	details, _ := fs.GetString(FlagDetails)
+	moniker, _ := fs.GetString(FlagMoniker)          //nolint:errcheck
+	identity, _ := fs.GetString(FlagIdentity)        //nolint:errcheck
+	website, _ := fs.GetString(FlagWebsite)          //nolint:errcheck
+	security, _ := fs.GetString(FlagSecurityContact) //nolint:errcheck
+	details, _ := fs.GetString(FlagDetails)          //nolint:errcheck
 	description := stakingtypes.NewDescription(
 		moniker,
 		identity,
@@ -158,11 +157,13 @@ func NewBuildCreateValidatorMsg(clientCtx client.Context, txf tx.Factory, fs *fl
 		return txf, nil, err
 	}
 
-	genOnly, _ := fs.GetBool(flags.FlagGenerateOnly)
+	genOnly, err := fs.GetBool(flags.FlagGenerateOnly)
+	if err != nil {
+		return txf, nil, sdkerrors.Wrap(err, "generate flag")
+	}
 	if genOnly {
-		ip, _ := fs.GetString(FlagIP)
-		nodeID, _ := fs.GetString(FlagNodeID)
-
+		ip, _ := fs.GetString(FlagIP)         //nolint:errcheck
+		nodeID, _ := fs.GetString(FlagNodeID) //nolint:errcheck
 		if nodeID != "" && ip != "" {
 			txf = txf.WithMemo(fmt.Sprintf("%s@%s:26656", nodeID, ip))
 		}
@@ -181,11 +182,11 @@ func NewEditValidatorCmd() *cobra.Command {
 				return err
 			}
 			valAddr := clientCtx.GetFromAddress()
-			moniker, _ := cmd.Flags().GetString(FlagMoniker)
-			identity, _ := cmd.Flags().GetString(FlagIdentity)
-			website, _ := cmd.Flags().GetString(FlagWebsite)
-			security, _ := cmd.Flags().GetString(FlagSecurityContact)
-			details, _ := cmd.Flags().GetString(FlagDetails)
+			moniker, _ := cmd.Flags().GetString(FlagMoniker)          //nolint:errcheck
+			identity, _ := cmd.Flags().GetString(FlagIdentity)        //nolint:errcheck
+			website, _ := cmd.Flags().GetString(FlagWebsite)          //nolint:errcheck
+			security, _ := cmd.Flags().GetString(FlagSecurityContact) //nolint:errcheck
+			details, _ := cmd.Flags().GetString(FlagDetails)          //nolint:errcheck
 			description := stakingtypes.NewDescription(moniker, identity, website, security, details)
 
 			msg := types.NewMsgUpdateValidator(valAddr, description)

--- a/x/poe/contract/common_test.go
+++ b/x/poe/contract/common_test.go
@@ -28,7 +28,7 @@ func setupPoEContractsNVal(t *testing.T, n int, mutators ...func(m *types.Genesi
 	t.Helper()
 	ctx, example := keeper.CreateDefaultTestInput(t)
 	deliverTXFn := unAuthorizedDeliverTXFn(t, ctx, example.PoEKeeper, example.TWasmKeeper.GetContractKeeper(), example.EncodingConfig.TxConfig.TxDecoder())
-	module := poe.NewAppModule(&example.PoEKeeper, example.TWasmKeeper, example.BankKeeper, example.AccountKeeper, deliverTXFn, example.EncodingConfig.TxConfig, example.TWasmKeeper.GetContractKeeper())
+	module := poe.NewAppModule(example.PoEKeeper, example.TWasmKeeper, example.BankKeeper, example.AccountKeeper, deliverTXFn, example.EncodingConfig.TxConfig, example.TWasmKeeper.GetContractKeeper())
 
 	mutator, expValidators := withRandomValidators(t, ctx, example, n)
 	gs := types.GenesisStateFixture(append([]func(m *types.GenesisState){mutator}, mutators...)...)
@@ -51,7 +51,7 @@ func setupPoEContractsNVal(t *testing.T, n int, mutators ...func(m *types.Genesi
 }
 
 // unAuthorizedDeliverTXFn applies the TX without ante handler checks for testing purpose
-func unAuthorizedDeliverTXFn(t *testing.T, ctx sdk.Context, k keeper.Keeper, contractKeeper wasmtypes.ContractOpsKeeper, txDecoder sdk.TxDecoder) func(tx abci.RequestDeliverTx) abci.ResponseDeliverTx {
+func unAuthorizedDeliverTXFn(t *testing.T, ctx sdk.Context, k *keeper.Keeper, contractKeeper wasmtypes.ContractOpsKeeper, txDecoder sdk.TxDecoder) func(tx abci.RequestDeliverTx) abci.ResponseDeliverTx {
 	t.Helper()
 	h := poe.NewHandler(k, contractKeeper, nil)
 	return func(tx abci.RequestDeliverTx) abci.ResponseDeliverTx {

--- a/x/poe/contract/contractio.go
+++ b/x/poe/contract/contractio.go
@@ -200,20 +200,20 @@ func ConvertToTendermintPubKey(key ValidatorPubkey) (crypto.PublicKey, error) {
 	}
 }
 
-// ContractAdapter is the base contract adapter type that contains common methods to interact with the contract
-type ContractAdapter struct {
+// BaseContractAdapter is the base contract adapter type that contains common methods to interact with the contract
+type BaseContractAdapter struct {
 	contractAddr     sdk.AccAddress
 	twasmKeeper      types.TWasmKeeper
 	addressLookupErr error
 }
 
-// NewContractAdapter constructor
-func NewContractAdapter(contractAddr sdk.AccAddress, twasmKeeper types.TWasmKeeper, addressLookupErr error) ContractAdapter {
-	return ContractAdapter{contractAddr: contractAddr, twasmKeeper: twasmKeeper, addressLookupErr: addressLookupErr}
+// NewBaseContractAdapter constructor
+func NewBaseContractAdapter(contractAddr sdk.AccAddress, twasmKeeper types.TWasmKeeper, addressLookupErr error) BaseContractAdapter {
+	return BaseContractAdapter{contractAddr: contractAddr, twasmKeeper: twasmKeeper, addressLookupErr: addressLookupErr}
 }
 
 // send message via execute entry point
-func (a ContractAdapter) doExecute(ctx sdk.Context, msg interface{}, sender sdk.AccAddress, coin ...sdk.Coin) error {
+func (a BaseContractAdapter) doExecute(ctx sdk.Context, msg interface{}, sender sdk.AccAddress, coin ...sdk.Coin) error {
 	if err := a.addressLookupErr; err != nil {
 		return err
 	}
@@ -233,7 +233,7 @@ type PageableResult interface {
 
 // execute a smart query with the contract that returns multiple elements
 // returns a cursor whenever the result set has more than 1 element
-func (a ContractAdapter) doPageableQuery(ctx sdk.Context, query interface{}, result interface{}) (PaginationCursor, error) {
+func (a BaseContractAdapter) doPageableQuery(ctx sdk.Context, query interface{}, result interface{}) (PaginationCursor, error) {
 	if err := a.addressLookupErr; err != nil {
 		return nil, err
 	}
@@ -248,9 +248,7 @@ func (a ContractAdapter) doPageableQuery(ctx sdk.Context, query interface{}, res
 	if err := json.Unmarshal(res, result); err != nil {
 		return nil, sdkerrors.Wrap(err, "unmarshal result")
 	}
-	switch p := result.(type) {
-	case PageableResult:
-		// has cursor value
+	if p, ok := result.(PageableResult); ok {
 		return p.PaginationCursor(res)
 	}
 	// no pagination support (in tgrade, yet)
@@ -258,7 +256,7 @@ func (a ContractAdapter) doPageableQuery(ctx sdk.Context, query interface{}, res
 }
 
 // execute a smart query with the contract
-func (a ContractAdapter) doQuery(ctx sdk.Context, query interface{}, result interface{}) error {
+func (a BaseContractAdapter) doQuery(ctx sdk.Context, query interface{}, result interface{}) error {
 	if err := a.addressLookupErr; err != nil {
 		return err
 	}
@@ -274,7 +272,7 @@ func (a ContractAdapter) doQuery(ctx sdk.Context, query interface{}, result inte
 }
 
 // Address returns contract address
-func (a ContractAdapter) Address() (sdk.AccAddress, error) {
+func (a BaseContractAdapter) Address() (sdk.AccAddress, error) {
 	return a.contractAddr, a.addressLookupErr
 }
 

--- a/x/poe/contract/tg4_engagement.go
+++ b/x/poe/contract/tg4_engagement.go
@@ -46,7 +46,7 @@ type UpdateMembersMsg struct {
 	Remove []string    `json:"remove"`
 }
 
-func (m *UpdateMembersMsg) Json(t *testing.T) string {
+func (m *UpdateMembersMsg) ToJSON(t *testing.T) string {
 	t.Helper()
 	switch {
 	case m.Add == nil:
@@ -63,13 +63,13 @@ func (m *UpdateMembersMsg) Json(t *testing.T) string {
 }
 
 type EngagementContractAdapter struct {
-	ContractAdapter
+	BaseContractAdapter
 }
 
 // NewEngagementContractAdapter constructor
 func NewEngagementContractAdapter(contractAddr sdk.AccAddress, twasmKeeper types.TWasmKeeper, addressLookupErr error) *EngagementContractAdapter {
 	return &EngagementContractAdapter{
-		ContractAdapter: NewContractAdapter(
+		BaseContractAdapter: NewBaseContractAdapter(
 			contractAddr,
 			twasmKeeper,
 			addressLookupErr,

--- a/x/poe/contract/tgrade_validator_voting.go
+++ b/x/poe/contract/tgrade_validator_voting.go
@@ -51,7 +51,7 @@ type Migration struct {
 	/// the contract address to be migrated
 	Contract string `json:"contract"`
 	/// a reference to the new WASM code that it should be migrated to
-	CodeId uint64 `json:"code_id"`
+	CodeID uint64 `json:"code_id"`
 	/// encoded message to be passed to perform the migration
 	MigrateMsg []byte `json:"migrate_msg"`
 }

--- a/x/poe/contract/tgrade_validator_voting_integration_test.go
+++ b/x/poe/contract/tgrade_validator_voting_integration_test.go
@@ -190,7 +190,7 @@ func TestValidatorsGovProposal(t *testing.T) {
 			src: contract.ValidatorProposal{
 				MigrateContract: &contract.Migration{
 					Contract:   valVotingAddr.String(),
-					CodeId:     codeID,
+					CodeID:     codeID,
 					MigrateMsg: []byte("{}"),
 				},
 			},
@@ -229,7 +229,7 @@ func TestValidatorsGovProposal(t *testing.T) {
 			for i, val := range vals[1:] {
 				t.Logf("%d %s - voting power: %s\n", i+1, val.OperatorAddress, val.Tokens)
 				opAddr, _ := sdk.AccAddressFromBech32(val.OperatorAddress)
-				require.NoError(t, adapter.VoteProposal(ctx, myProposalID, contract.YES_VOTE, opAddr), "voter: %d", i)
+				require.NoError(t, adapter.VoteProposal(ctx, myProposalID, contract.YesVote, opAddr), "voter: %d", i)
 			}
 			// then
 			rsp, err = adapter.QueryProposal(ctx, myProposalID)

--- a/x/poe/contract/tgrade_valset.go
+++ b/x/poe/contract/tgrade_valset.go
@@ -342,13 +342,13 @@ func SimulateActiveValidators(ctx sdk.Context, k types.SmartQuerier, valset sdk.
 }
 
 type ValsetContractAdapter struct {
-	ContractAdapter
+	BaseContractAdapter
 }
 
 // NewValsetContractAdapter constructor
 func NewValsetContractAdapter(contractAddr sdk.AccAddress, twasmKeeper types.TWasmKeeper, addressLookupErr error) *ValsetContractAdapter {
 	return &ValsetContractAdapter{
-		ContractAdapter: NewContractAdapter(
+		BaseContractAdapter: NewBaseContractAdapter(
 			contractAddr,
 			twasmKeeper,
 			addressLookupErr,

--- a/x/poe/contract/voting.go
+++ b/x/poe/contract/voting.go
@@ -27,10 +27,10 @@ type VotingRules struct {
 type Vote string
 
 const (
-	YES_VOTE     Vote = "yes"
-	NO_VOTE      Vote = "no"
-	ABSTAIN_VOTE Vote = "abstain"
-	VETO_VOTE    Vote = "veto"
+	YesVote     Vote = "yes"
+	NoVote      Vote = "no"
+	AbstainVote Vote = "abstain"
+	VetoVote    Vote = "veto"
 )
 
 type ProposalStatus string
@@ -127,13 +127,13 @@ type VoterListResponse struct {
 }
 
 type VotingContractAdapter struct {
-	ContractAdapter
+	BaseContractAdapter
 }
 
 // NewVotingContractAdapter  constructor
 func NewVotingContractAdapter(contractAddr sdk.AccAddress, twasmKeeper types.TWasmKeeper, addressLookupErr error) VotingContractAdapter {
 	return VotingContractAdapter{
-		ContractAdapter: NewContractAdapter(
+		BaseContractAdapter: NewBaseContractAdapter(
 			contractAddr,
 			twasmKeeper,
 			addressLookupErr,

--- a/x/poe/keeper/contracts.go
+++ b/x/poe/keeper/contracts.go
@@ -16,7 +16,7 @@ type DistributionContract interface {
 	Address() (sdk.AccAddress, error)
 }
 
-func (k Keeper) DistributionContract(ctx sdk.Context) DistributionContract {
+func (k *Keeper) DistributionContract(ctx sdk.Context) DistributionContract {
 	distContractAddr, err := k.GetPoEContractAddress(ctx, types.PoEContractTypeDistribution)
 	return contract.NewDistributionContractAdapter(distContractAddr, k.twasmKeeper, err)
 }
@@ -31,7 +31,7 @@ type ValsetContract interface {
 	Address() (sdk.AccAddress, error)
 }
 
-func (k Keeper) ValsetContract(ctx sdk.Context) ValsetContract {
+func (k *Keeper) ValsetContract(ctx sdk.Context) ValsetContract {
 	distContractAddr, err := k.GetPoEContractAddress(ctx, types.PoEContractTypeValset)
 	return contract.NewValsetContractAdapter(distContractAddr, k.twasmKeeper, err)
 }
@@ -45,7 +45,7 @@ type StakeContract interface {
 	Address() (sdk.AccAddress, error)
 }
 
-func (k Keeper) StakeContract(ctx sdk.Context) StakeContract {
+func (k *Keeper) StakeContract(ctx sdk.Context) StakeContract {
 	distContractAddr, err := k.GetPoEContractAddress(ctx, types.PoEContractTypeStaking)
 	return contract.NewStakeContractAdapter(distContractAddr, k.twasmKeeper, err)
 }
@@ -57,7 +57,7 @@ type EngagementContract interface {
 	Address() (sdk.AccAddress, error)
 }
 
-func (k Keeper) EngagementContract(ctx sdk.Context) EngagementContract {
+func (k *Keeper) EngagementContract(ctx sdk.Context) EngagementContract {
 	engContractAddr, err := k.GetPoEContractAddress(ctx, types.PoEContractTypeEngagement)
 	return contract.NewEngagementContractAdapter(engContractAddr, k.twasmKeeper, err)
 }

--- a/x/poe/keeper/engagement.go
+++ b/x/poe/keeper/engagement.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GetEngagementPoints read engagement points from contract
-func (k Keeper) GetEngagementPoints(ctx sdk.Context, opAddr sdk.AccAddress) (uint64, error) {
+func (k *Keeper) GetEngagementPoints(ctx sdk.Context, opAddr sdk.AccAddress) (uint64, error) {
 	engagementContractAddr, err := k.GetPoEContractAddress(ctx, types.PoEContractTypeEngagement)
 	if err != nil {
 		return 0, sdkerrors.Wrap(err, "get contract addr")
@@ -25,7 +25,7 @@ func (k Keeper) GetEngagementPoints(ctx sdk.Context, opAddr sdk.AccAddress) (uin
 }
 
 // setEngagementPoints set new engagement point value.
-func (k Keeper) setEngagementPoints(ctx sdk.Context, opAddr sdk.AccAddress, points uint64) error {
+func (k *Keeper) setEngagementPoints(ctx sdk.Context, opAddr sdk.AccAddress, points uint64) error {
 	engagementContractAddr, err := k.GetPoEContractAddress(ctx, types.PoEContractTypeEngagement)
 	if err != nil {
 		return sdkerrors.Wrap(err, "get contract addr")
@@ -34,7 +34,7 @@ func (k Keeper) setEngagementPoints(ctx sdk.Context, opAddr sdk.AccAddress, poin
 }
 
 // SetValidatorInitialEngagementPoints set an initial amount of engagement points for a validator when it matches self delegation preconditions
-func (k Keeper) SetValidatorInitialEngagementPoints(ctx sdk.Context, opAddr sdk.AccAddress, selfDelegation sdk.Coin) error {
+func (k *Keeper) SetValidatorInitialEngagementPoints(ctx sdk.Context, opAddr sdk.AccAddress, selfDelegation sdk.Coin) error {
 	// distribute engagement points enabled ?
 	newPoints := k.GetInitialValidatorEngagementPoints(ctx)
 	if newPoints == 0 {

--- a/x/poe/keeper/genesis_test.go
+++ b/x/poe/keeper/genesis_test.go
@@ -141,7 +141,7 @@ func TestExportGenesis(t *testing.T) {
 	})
 
 	// when
-	gs := ExportGenesis(ctx, &k)
+	gs := ExportGenesis(ctx, k)
 
 	// then
 	require.NotNil(t, gs)

--- a/x/poe/keeper/historical_info.go
+++ b/x/poe/keeper/historical_info.go
@@ -13,7 +13,7 @@ import (
 var _ ibccoretypes.StakingKeeper = &Keeper{}
 
 // GetHistoricalInfo gets the historical info at a given height
-func (k Keeper) GetHistoricalInfo(ctx sdk.Context, height int64) (stakingtypes.HistoricalInfo, bool) {
+func (k *Keeper) GetHistoricalInfo(ctx sdk.Context, height int64) (stakingtypes.HistoricalInfo, bool) {
 	store := ctx.KVStore(k.storeKey)
 	key := getHistoricalInfoKey(height)
 
@@ -26,7 +26,7 @@ func (k Keeper) GetHistoricalInfo(ctx sdk.Context, height int64) (stakingtypes.H
 }
 
 // SetHistoricalInfo sets the historical info at a given height
-func (k Keeper) SetHistoricalInfo(ctx sdk.Context, height int64, hi *stakingtypes.HistoricalInfo) {
+func (k *Keeper) SetHistoricalInfo(ctx sdk.Context, height int64, hi *stakingtypes.HistoricalInfo) {
 	store := ctx.KVStore(k.storeKey)
 	key := getHistoricalInfoKey(height)
 	value := k.codec.MustMarshal(hi)
@@ -34,7 +34,7 @@ func (k Keeper) SetHistoricalInfo(ctx sdk.Context, height int64, hi *stakingtype
 }
 
 // DeleteHistoricalInfo deletes the historical info at a given height
-func (k Keeper) DeleteHistoricalInfo(ctx sdk.Context, height int64) {
+func (k *Keeper) DeleteHistoricalInfo(ctx sdk.Context, height int64) {
 	store := ctx.KVStore(k.storeKey)
 	key := getHistoricalInfoKey(height)
 
@@ -44,7 +44,7 @@ func (k Keeper) DeleteHistoricalInfo(ctx sdk.Context, height int64) {
 // iterateHistoricalInfo provides an interator over all stored HistoricalInfo
 //  objects. For each HistoricalInfo object, cb will be called. If the cb returns
 // true, the iterator will close and stop.
-func (k Keeper) iterateHistoricalInfo(ctx sdk.Context, cb func(stakingtypes.HistoricalInfo) bool) {
+func (k *Keeper) iterateHistoricalInfo(ctx sdk.Context, cb func(stakingtypes.HistoricalInfo) bool) { //nolint:unused
 	store := ctx.KVStore(k.storeKey)
 
 	iter := sdk.KVStorePrefixIterator(store, types.HistoricalInfoKey)
@@ -59,7 +59,7 @@ func (k Keeper) iterateHistoricalInfo(ctx sdk.Context, cb func(stakingtypes.Hist
 }
 
 // getAllHistoricalInfo returns all stored HistoricalInfo objects.
-func (k Keeper) getAllHistoricalInfo(ctx sdk.Context) []stakingtypes.HistoricalInfo {
+func (k *Keeper) getAllHistoricalInfo(ctx sdk.Context) []stakingtypes.HistoricalInfo { //nolint:unused
 	var infos []stakingtypes.HistoricalInfo
 
 	k.iterateHistoricalInfo(ctx, func(histInfo stakingtypes.HistoricalInfo) bool {
@@ -72,7 +72,7 @@ func (k Keeper) getAllHistoricalInfo(ctx sdk.Context) []stakingtypes.HistoricalI
 
 // TrackHistoricalInfo saves the latest historical-info and deletes the oldest
 // heights that are below pruning height
-func (k Keeper) TrackHistoricalInfo(ctx sdk.Context) {
+func (k *Keeper) TrackHistoricalInfo(ctx sdk.Context) {
 	entryNum := k.HistoricalEntries(ctx)
 
 	// Prune store to ensure we only have parameter-defined historical entries.

--- a/x/poe/keeper/keeper.go
+++ b/x/poe/keeper/keeper.go
@@ -52,14 +52,14 @@ func NewKeeper(
 }
 
 // SetPoEContractAddress stores the contract address for the given type. If one exists already then it is overwritten.
-func (k Keeper) SetPoEContractAddress(ctx sdk.Context, ctype types.PoEContractType, contractAddr sdk.AccAddress) {
+func (k *Keeper) SetPoEContractAddress(ctx sdk.Context, ctype types.PoEContractType, contractAddr sdk.AccAddress) {
 	store := ctx.KVStore(k.storeKey)
 	store.Set(poeContractAddressKey(ctype), contractAddr.Bytes())
 	k.contractAddrCache.Store(ctype, contractAddr)
 }
 
 // GetPoEContractAddress get the stored contract address for the given type or returns an error when not exists (yet)
-func (k Keeper) GetPoEContractAddress(ctx sdk.Context, ctype types.PoEContractType) (sdk.AccAddress, error) {
+func (k *Keeper) GetPoEContractAddress(ctx sdk.Context, ctype types.PoEContractType) (sdk.AccAddress, error) {
 	if err := ctype.ValidateBasic(); err != nil {
 		return nil, sdkerrors.Wrap(err, "contract type")
 	}
@@ -83,7 +83,7 @@ func (k Keeper) GetPoEContractAddress(ctx sdk.Context, ctype types.PoEContractTy
 
 // IteratePoEContracts for each persisted PoE contract the given callback is called.
 // When the callback returns true, the loop is aborted early.
-func (k Keeper) IteratePoEContracts(ctx sdk.Context, cb func(types.PoEContractType, sdk.AccAddress) bool) {
+func (k *Keeper) IteratePoEContracts(ctx sdk.Context, cb func(types.PoEContractType, sdk.AccAddress) bool) {
 	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), types.ContractPrefix)
 	iter := prefixStore.Iterator(nil, nil)
 	defer iter.Close()
@@ -97,7 +97,7 @@ func (k Keeper) IteratePoEContracts(ctx sdk.Context, cb func(types.PoEContractTy
 }
 
 // UnbondingTime returns the unbonding period from the staking contract
-func (k Keeper) UnbondingTime(ctx sdk.Context) time.Duration {
+func (k *Keeper) UnbondingTime(ctx sdk.Context) time.Duration {
 	rsp, err := k.StakeContract(ctx).QueryStakingUnbondingPeriod(ctx)
 	if err != nil {
 		panic(fmt.Sprintf("unboding period: %s", err))
@@ -105,7 +105,7 @@ func (k Keeper) UnbondingTime(ctx sdk.Context) time.Duration {
 	return rsp
 }
 
-func (k Keeper) GetBondDenom(ctx sdk.Context) string {
+func (k *Keeper) GetBondDenom(ctx sdk.Context) string {
 	return types.DefaultBondDenom
 }
 

--- a/x/poe/keeper/legacy_distribution_querier.go
+++ b/x/poe/keeper/legacy_distribution_querier.go
@@ -12,18 +12,18 @@ import (
 	"github.com/confio/tgrade/x/poe/types"
 )
 
-var _ distributiontypes.QueryServer = &legacyDistributionGRPCQuerier{}
+var _ distributiontypes.QueryServer = &LegacyDistributionGRPCQuerier{}
 
-type legacyDistributionGRPCQuerier struct {
+type LegacyDistributionGRPCQuerier struct {
 	keeper      ViewKeeper
 	queryServer types.QueryServer
 }
 
-func NewLegacyDistributionGRPCQuerier(keeper ViewKeeper) *legacyDistributionGRPCQuerier { //nolint:golint
-	return &legacyDistributionGRPCQuerier{keeper: keeper, queryServer: NewGrpcQuerier(keeper)}
+func NewLegacyDistributionGRPCQuerier(keeper ViewKeeper) *LegacyDistributionGRPCQuerier { //nolint:golint
+	return &LegacyDistributionGRPCQuerier{keeper: keeper, queryServer: NewQuerier(keeper)}
 }
 
-func (q legacyDistributionGRPCQuerier) ValidatorOutstandingRewards(c context.Context, req *distributiontypes.QueryValidatorOutstandingRewardsRequest) (*distributiontypes.QueryValidatorOutstandingRewardsResponse, error) {
+func (q LegacyDistributionGRPCQuerier) ValidatorOutstandingRewards(c context.Context, req *distributiontypes.QueryValidatorOutstandingRewardsRequest) (*distributiontypes.QueryValidatorOutstandingRewardsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -38,7 +38,7 @@ func (q legacyDistributionGRPCQuerier) ValidatorOutstandingRewards(c context.Con
 	}, nil
 }
 
-func (q legacyDistributionGRPCQuerier) ValidatorCommission(c context.Context, req *distributiontypes.QueryValidatorCommissionRequest) (*distributiontypes.QueryValidatorCommissionResponse, error) {
+func (q LegacyDistributionGRPCQuerier) ValidatorCommission(c context.Context, req *distributiontypes.QueryValidatorCommissionRequest) (*distributiontypes.QueryValidatorCommissionResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -54,7 +54,7 @@ func (q legacyDistributionGRPCQuerier) ValidatorCommission(c context.Context, re
 	}, nil
 }
 
-func (q legacyDistributionGRPCQuerier) ValidatorSlashes(c context.Context, req *distributiontypes.QueryValidatorSlashesRequest) (*distributiontypes.QueryValidatorSlashesResponse, error) {
+func (q LegacyDistributionGRPCQuerier) ValidatorSlashes(c context.Context, req *distributiontypes.QueryValidatorSlashesRequest) (*distributiontypes.QueryValidatorSlashesResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -82,7 +82,7 @@ func (q legacyDistributionGRPCQuerier) ValidatorSlashes(c context.Context, req *
 	}, nil
 }
 
-func (q legacyDistributionGRPCQuerier) DelegationRewards(c context.Context, req *distributiontypes.QueryDelegationRewardsRequest) (*distributiontypes.QueryDelegationRewardsResponse, error) {
+func (q LegacyDistributionGRPCQuerier) DelegationRewards(c context.Context, req *distributiontypes.QueryDelegationRewardsRequest) (*distributiontypes.QueryDelegationRewardsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -96,7 +96,7 @@ func (q legacyDistributionGRPCQuerier) DelegationRewards(c context.Context, req 
 	return &distributiontypes.QueryDelegationRewardsResponse{}, nil
 }
 
-func (q legacyDistributionGRPCQuerier) DelegationTotalRewards(c context.Context, req *distributiontypes.QueryDelegationTotalRewardsRequest) (*distributiontypes.QueryDelegationTotalRewardsResponse, error) {
+func (q LegacyDistributionGRPCQuerier) DelegationTotalRewards(c context.Context, req *distributiontypes.QueryDelegationTotalRewardsRequest) (*distributiontypes.QueryDelegationTotalRewardsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -110,7 +110,7 @@ func (q legacyDistributionGRPCQuerier) DelegationTotalRewards(c context.Context,
 	return &distributiontypes.QueryDelegationTotalRewardsResponse{}, nil
 }
 
-func (q legacyDistributionGRPCQuerier) DelegatorValidators(c context.Context, req *distributiontypes.QueryDelegatorValidatorsRequest) (*distributiontypes.QueryDelegatorValidatorsResponse, error) {
+func (q LegacyDistributionGRPCQuerier) DelegatorValidators(c context.Context, req *distributiontypes.QueryDelegatorValidatorsRequest) (*distributiontypes.QueryDelegatorValidatorsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -134,7 +134,7 @@ func (q legacyDistributionGRPCQuerier) DelegatorValidators(c context.Context, re
 	}, nil
 }
 
-func (q legacyDistributionGRPCQuerier) DelegatorWithdrawAddress(c context.Context, req *distributiontypes.QueryDelegatorWithdrawAddressRequest) (*distributiontypes.QueryDelegatorWithdrawAddressResponse, error) {
+func (q LegacyDistributionGRPCQuerier) DelegatorWithdrawAddress(c context.Context, req *distributiontypes.QueryDelegatorWithdrawAddressRequest) (*distributiontypes.QueryDelegatorWithdrawAddressResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -158,7 +158,7 @@ func (q legacyDistributionGRPCQuerier) DelegatorWithdrawAddress(c context.Contex
 	}, nil
 }
 
-func (q legacyDistributionGRPCQuerier) CommunityPool(c context.Context, req *distributiontypes.QueryCommunityPoolRequest) (*distributiontypes.QueryCommunityPoolResponse, error) {
+func (q LegacyDistributionGRPCQuerier) CommunityPool(c context.Context, req *distributiontypes.QueryCommunityPoolRequest) (*distributiontypes.QueryCommunityPoolResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -166,7 +166,7 @@ func (q legacyDistributionGRPCQuerier) CommunityPool(c context.Context, req *dis
 }
 
 // Params is not supported. Method returns default distribution module params.
-func (q legacyDistributionGRPCQuerier) Params(c context.Context, req *distributiontypes.QueryParamsRequest) (*distributiontypes.QueryParamsResponse, error) {
+func (q LegacyDistributionGRPCQuerier) Params(c context.Context, req *distributiontypes.QueryParamsRequest) (*distributiontypes.QueryParamsResponse, error) {
 	return &distributiontypes.QueryParamsResponse{
 		Params: distributiontypes.Params{
 			CommunityTax:        sdk.ZeroDec(),

--- a/x/poe/keeper/legacy_slashing_querier.go
+++ b/x/poe/keeper/legacy_slashing_querier.go
@@ -9,18 +9,18 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var _ slashingtypes.QueryServer = &legacySlashingGRPCQuerier{}
+var _ slashingtypes.QueryServer = &LegacySlashingGRPCQuerier{}
 
-type legacySlashingGRPCQuerier struct {
+type LegacySlashingGRPCQuerier struct {
 	keeper ContractSource
 }
 
-func NewLegacySlashingGRPCQuerier(keeper ContractSource) *legacySlashingGRPCQuerier { //nolint:golint
-	return &legacySlashingGRPCQuerier{keeper: keeper}
+func NewLegacySlashingGRPCQuerier(keeper ContractSource) *LegacySlashingGRPCQuerier { //nolint:golint
+	return &LegacySlashingGRPCQuerier{keeper: keeper}
 }
 
 // SigningInfo legacy support for cosmos-sdk signing info. Note that not all field are available on tgrade
-func (g legacySlashingGRPCQuerier) SigningInfo(c context.Context, req *slashingtypes.QuerySigningInfoRequest) (*slashingtypes.QuerySigningInfoResponse, error) {
+func (g LegacySlashingGRPCQuerier) SigningInfo(c context.Context, req *slashingtypes.QuerySigningInfoRequest) (*slashingtypes.QuerySigningInfoResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -40,13 +40,13 @@ func (g legacySlashingGRPCQuerier) SigningInfo(c context.Context, req *slashingt
 }
 
 // SigningInfos is not supported and will return unimplemented error
-func (g legacySlashingGRPCQuerier) SigningInfos(c context.Context, req *slashingtypes.QuerySigningInfosRequest) (*slashingtypes.QuerySigningInfosResponse, error) {
+func (g LegacySlashingGRPCQuerier) SigningInfos(c context.Context, req *slashingtypes.QuerySigningInfosRequest) (*slashingtypes.QuerySigningInfosResponse, error) {
 	logNotImplemented(sdk.UnwrapSDKContext(c), "SigningInfos")
 	return nil, status.Error(codes.Unimplemented, "not available, yet")
 }
 
 // Params is not supported. Method returns default slashing module params.
-func (g legacySlashingGRPCQuerier) Params(c context.Context, req *slashingtypes.QueryParamsRequest) (*slashingtypes.QueryParamsResponse, error) {
+func (g LegacySlashingGRPCQuerier) Params(c context.Context, req *slashingtypes.QueryParamsRequest) (*slashingtypes.QueryParamsResponse, error) {
 	return &slashingtypes.QueryParamsResponse{
 		Params: slashingtypes.Params{
 			SignedBlocksWindow:      0,

--- a/x/poe/keeper/legacy_staking_querier.go
+++ b/x/poe/keeper/legacy_staking_querier.go
@@ -11,35 +11,35 @@ import (
 	"github.com/confio/tgrade/x/poe/types"
 )
 
-var _ stakingtypes.QueryServer = &legacyStakingGRPCQuerier{}
+var _ stakingtypes.QueryServer = &LegacyStakingGRPCQuerier{}
 
 type stakingQuerierKeeper interface {
 	ViewKeeper
 	HistoricalEntries(ctx sdk.Context) uint32
 }
-type legacyStakingGRPCQuerier struct {
+type LegacyStakingGRPCQuerier struct {
 	keeper      stakingQuerierKeeper
 	queryServer types.QueryServer
 }
 
-func NewLegacyStakingGRPCQuerier(poeKeeper stakingQuerierKeeper) *legacyStakingGRPCQuerier { //nolint:golint
-	return &legacyStakingGRPCQuerier{keeper: poeKeeper, queryServer: NewGrpcQuerier(poeKeeper)}
+func NewLegacyStakingGRPCQuerier(poeKeeper stakingQuerierKeeper) *LegacyStakingGRPCQuerier { //nolint:golint
+	return &LegacyStakingGRPCQuerier{keeper: poeKeeper, queryServer: NewQuerier(poeKeeper)}
 }
 
 // Validators legacy support for querying all validators that match the given status
-func (q legacyStakingGRPCQuerier) Validators(c context.Context, req *stakingtypes.QueryValidatorsRequest) (*stakingtypes.QueryValidatorsResponse, error) {
+func (q LegacyStakingGRPCQuerier) Validators(c context.Context, req *stakingtypes.QueryValidatorsRequest) (*stakingtypes.QueryValidatorsResponse, error) {
 	return q.queryServer.Validators(c, req)
 }
 
 // Validator legacy support for querying the validator info for a given validator address.
 // returns NotFound error code when none exists for the given address
-func (q legacyStakingGRPCQuerier) Validator(c context.Context, req *stakingtypes.QueryValidatorRequest) (*stakingtypes.QueryValidatorResponse, error) {
+func (q LegacyStakingGRPCQuerier) Validator(c context.Context, req *stakingtypes.QueryValidatorRequest) (*stakingtypes.QueryValidatorResponse, error) {
 	return q.queryServer.Validator(c, req)
 }
 
 // ValidatorDelegations legacy support for querying the delegate infos for a given validator.
 // In PoE only validator operators do self delegations/ unbondings. Result set is either zero or one element.
-func (q legacyStakingGRPCQuerier) ValidatorDelegations(c context.Context, req *stakingtypes.QueryValidatorDelegationsRequest) (*stakingtypes.QueryValidatorDelegationsResponse, error) {
+func (q LegacyStakingGRPCQuerier) ValidatorDelegations(c context.Context, req *stakingtypes.QueryValidatorDelegationsRequest) (*stakingtypes.QueryValidatorDelegationsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -67,7 +67,7 @@ func (q legacyStakingGRPCQuerier) ValidatorDelegations(c context.Context, req *s
 
 // ValidatorUnbondingDelegations legacy support for querying the unbonding delegations of a validator.
 // In PoE only validator operators do self delegations/ unbondings. Result set is either zero or one element.
-func (q legacyStakingGRPCQuerier) ValidatorUnbondingDelegations(c context.Context, req *stakingtypes.QueryValidatorUnbondingDelegationsRequest) (*stakingtypes.QueryValidatorUnbondingDelegationsResponse, error) {
+func (q LegacyStakingGRPCQuerier) ValidatorUnbondingDelegations(c context.Context, req *stakingtypes.QueryValidatorUnbondingDelegationsRequest) (*stakingtypes.QueryValidatorUnbondingDelegationsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -91,7 +91,7 @@ func (q legacyStakingGRPCQuerier) ValidatorUnbondingDelegations(c context.Contex
 
 // Delegation legacy support for querying the delegate info for a given validator delegator pair
 // Returns response or NotFound error when none exists.
-func (q legacyStakingGRPCQuerier) Delegation(c context.Context, req *stakingtypes.QueryDelegationRequest) (*stakingtypes.QueryDelegationResponse, error) {
+func (q LegacyStakingGRPCQuerier) Delegation(c context.Context, req *stakingtypes.QueryDelegationRequest) (*stakingtypes.QueryDelegationResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -126,7 +126,7 @@ func (q legacyStakingGRPCQuerier) Delegation(c context.Context, req *stakingtype
 
 // UnbondingDelegation legacy support for querying the unbonding info for given validator delegator pair
 // Returns response or NotFound error when none exists.
-func (q legacyStakingGRPCQuerier) UnbondingDelegation(c context.Context, req *stakingtypes.QueryUnbondingDelegationRequest) (*stakingtypes.QueryUnbondingDelegationResponse, error) {
+func (q LegacyStakingGRPCQuerier) UnbondingDelegation(c context.Context, req *stakingtypes.QueryUnbondingDelegationRequest) (*stakingtypes.QueryUnbondingDelegationResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -161,7 +161,7 @@ func (q legacyStakingGRPCQuerier) UnbondingDelegation(c context.Context, req *st
 
 // DelegatorDelegations legacy support for querying all delegations of a given delegator address.
 // In PoE only validator operators do self delegations/ unbondings. Result set is either zero or one element.
-func (q legacyStakingGRPCQuerier) DelegatorDelegations(c context.Context, req *stakingtypes.QueryDelegatorDelegationsRequest) (*stakingtypes.QueryDelegatorDelegationsResponse, error) {
+func (q LegacyStakingGRPCQuerier) DelegatorDelegations(c context.Context, req *stakingtypes.QueryDelegatorDelegationsRequest) (*stakingtypes.QueryDelegatorDelegationsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -180,7 +180,7 @@ func (q legacyStakingGRPCQuerier) DelegatorDelegations(c context.Context, req *s
 
 // DelegatorUnbondingDelegations legacy support for querying all unbonding delegations of a given delegator address
 // In PoE only validator operators do self delegations/ unbondings. Result set is either zero or one element.
-func (q legacyStakingGRPCQuerier) DelegatorUnbondingDelegations(c context.Context, req *stakingtypes.QueryDelegatorUnbondingDelegationsRequest) (*stakingtypes.QueryDelegatorUnbondingDelegationsResponse, error) {
+func (q LegacyStakingGRPCQuerier) DelegatorUnbondingDelegations(c context.Context, req *stakingtypes.QueryDelegatorUnbondingDelegationsRequest) (*stakingtypes.QueryDelegatorUnbondingDelegationsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -197,14 +197,14 @@ func (q legacyStakingGRPCQuerier) DelegatorUnbondingDelegations(c context.Contex
 	}, nil
 }
 
-func (q legacyStakingGRPCQuerier) Redelegations(c context.Context, req *stakingtypes.QueryRedelegationsRequest) (*stakingtypes.QueryRedelegationsResponse, error) {
+func (q LegacyStakingGRPCQuerier) Redelegations(c context.Context, req *stakingtypes.QueryRedelegationsRequest) (*stakingtypes.QueryRedelegationsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
 	return &stakingtypes.QueryRedelegationsResponse{}, nil
 }
 
-func (q legacyStakingGRPCQuerier) DelegatorValidators(c context.Context, req *stakingtypes.QueryDelegatorValidatorsRequest) (*stakingtypes.QueryDelegatorValidatorsResponse, error) {
+func (q LegacyStakingGRPCQuerier) DelegatorValidators(c context.Context, req *stakingtypes.QueryDelegatorValidatorsRequest) (*stakingtypes.QueryDelegatorValidatorsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -219,7 +219,7 @@ func (q legacyStakingGRPCQuerier) DelegatorValidators(c context.Context, req *st
 	}, nil
 }
 
-func (q legacyStakingGRPCQuerier) DelegatorValidator(c context.Context, req *stakingtypes.QueryDelegatorValidatorRequest) (*stakingtypes.QueryDelegatorValidatorResponse, error) {
+func (q LegacyStakingGRPCQuerier) DelegatorValidator(c context.Context, req *stakingtypes.QueryDelegatorValidatorRequest) (*stakingtypes.QueryDelegatorValidatorResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -235,7 +235,7 @@ func (q legacyStakingGRPCQuerier) DelegatorValidator(c context.Context, req *sta
 }
 
 // HistoricalInfo queries the historical info for given height
-func (q legacyStakingGRPCQuerier) HistoricalInfo(c context.Context, req *stakingtypes.QueryHistoricalInfoRequest) (*stakingtypes.QueryHistoricalInfoResponse, error) {
+func (q LegacyStakingGRPCQuerier) HistoricalInfo(c context.Context, req *stakingtypes.QueryHistoricalInfoRequest) (*stakingtypes.QueryHistoricalInfoResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -247,7 +247,7 @@ func (q legacyStakingGRPCQuerier) HistoricalInfo(c context.Context, req *staking
 	return &stakingtypes.QueryHistoricalInfoResponse{Hist: &hi}, nil
 }
 
-func (q legacyStakingGRPCQuerier) Pool(c context.Context, req *stakingtypes.QueryPoolRequest) (*stakingtypes.QueryPoolResponse, error) {
+func (q LegacyStakingGRPCQuerier) Pool(c context.Context, req *stakingtypes.QueryPoolRequest) (*stakingtypes.QueryPoolResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -256,7 +256,7 @@ func (q legacyStakingGRPCQuerier) Pool(c context.Context, req *stakingtypes.Quer
 	return nil, status.Error(codes.Unimplemented, "not available, yet")
 }
 
-func (q legacyStakingGRPCQuerier) Params(c context.Context, req *stakingtypes.QueryParamsRequest) (*stakingtypes.QueryParamsResponse, error) {
+func (q LegacyStakingGRPCQuerier) Params(c context.Context, req *stakingtypes.QueryParamsRequest) (*stakingtypes.QueryParamsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}

--- a/x/poe/keeper/params.go
+++ b/x/poe/keeper/params.go
@@ -8,24 +8,24 @@ import (
 
 // HistoricalEntries = number of historical info entries
 // to persist in store
-func (k Keeper) HistoricalEntries(ctx sdk.Context) (res uint32) {
+func (k *Keeper) HistoricalEntries(ctx sdk.Context) (res uint32) {
 	k.paramStore.Get(ctx, types.KeyHistoricalEntries, &res)
 	return
 }
 
 // GetInitialValidatorEngagementPoints get number of engagement for any new validator joining post genesis
-func (k Keeper) GetInitialValidatorEngagementPoints(ctx sdk.Context) (res uint64) {
+func (k *Keeper) GetInitialValidatorEngagementPoints(ctx sdk.Context) (res uint64) {
 	k.paramStore.Get(ctx, types.KeyInitialValEngagementPoints, &res)
 	return
 }
 
-func (k Keeper) MinimumDelegationAmounts(ctx sdk.Context) (res sdk.Coins) {
+func (k *Keeper) MinimumDelegationAmounts(ctx sdk.Context) (res sdk.Coins) {
 	k.paramStore.Get(ctx, types.KeyMinDelegationAmounts, &res)
 	return
 }
 
 // GetParams returns all parameters as types.Params
-func (k Keeper) GetParams(ctx sdk.Context) types.Params {
+func (k *Keeper) GetParams(ctx sdk.Context) types.Params {
 	return types.NewParams(
 		k.HistoricalEntries(ctx),
 		k.GetInitialValidatorEngagementPoints(ctx),
@@ -34,6 +34,6 @@ func (k Keeper) GetParams(ctx sdk.Context) types.Params {
 }
 
 // SetParams set the params
-func (k Keeper) setParams(ctx sdk.Context, params types.Params) {
+func (k *Keeper) setParams(ctx sdk.Context, params types.Params) {
 	k.paramStore.SetParamSet(ctx, &params)
 }

--- a/x/poe/keeper/querier.go
+++ b/x/poe/keeper/querier.go
@@ -16,7 +16,7 @@ import (
 	"github.com/confio/tgrade/x/poe/types"
 )
 
-var _ types.QueryServer = &grpcQuerier{}
+var _ types.QueryServer = &Querier{}
 
 // ContractSource subset of poe keeper
 type ContractSource interface {
@@ -33,17 +33,17 @@ type ViewKeeper interface {
 	EngagementContract(ctx sdk.Context) EngagementContract
 }
 
-type grpcQuerier struct {
+type Querier struct {
 	keeper ViewKeeper
 }
 
-// NewGrpcQuerier constructor
-func NewGrpcQuerier(keeper ViewKeeper) *grpcQuerier {
-	return &grpcQuerier{keeper: keeper}
+// NewQuerier constructor
+func NewQuerier(keeper ViewKeeper) *Querier {
+	return &Querier{keeper: keeper}
 }
 
 // ContractAddress query PoE contract address for given type
-func (q grpcQuerier) ContractAddress(c context.Context, req *types.QueryContractAddressRequest) (*types.QueryContractAddressResponse, error) {
+func (q Querier) ContractAddress(c context.Context, req *types.QueryContractAddressRequest) (*types.QueryContractAddressResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -59,7 +59,7 @@ func (q grpcQuerier) ContractAddress(c context.Context, req *types.QueryContract
 }
 
 // Validators query all validators that match the given status.
-func (q grpcQuerier) Validators(c context.Context, req *stakingtypes.QueryValidatorsRequest) (*stakingtypes.QueryValidatorsResponse, error) {
+func (q Querier) Validators(c context.Context, req *stakingtypes.QueryValidatorsRequest) (*stakingtypes.QueryValidatorsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -91,7 +91,7 @@ func (q grpcQuerier) Validators(c context.Context, req *stakingtypes.QueryValida
 
 // Validator queries validator info for a given validator address.
 // returns NotFound error code when none exists for the given address
-func (q grpcQuerier) Validator(c context.Context, req *stakingtypes.QueryValidatorRequest) (*stakingtypes.QueryValidatorResponse, error) {
+func (q Querier) Validator(c context.Context, req *stakingtypes.QueryValidatorRequest) (*stakingtypes.QueryValidatorResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -117,7 +117,7 @@ func (q grpcQuerier) Validator(c context.Context, req *stakingtypes.QueryValidat
 }
 
 // UnbondingPeriod query the global unbonding period
-func (q grpcQuerier) UnbondingPeriod(c context.Context, req *types.QueryUnbondingPeriodRequest) (*types.QueryUnbondingPeriodResponse, error) {
+func (q Querier) UnbondingPeriod(c context.Context, req *types.QueryUnbondingPeriodRequest) (*types.QueryUnbondingPeriodResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -131,7 +131,7 @@ func (q grpcQuerier) UnbondingPeriod(c context.Context, req *types.QueryUnbondin
 	}, nil
 }
 
-func (q grpcQuerier) ValidatorDelegation(c context.Context, req *types.QueryValidatorDelegationRequest) (*types.QueryValidatorDelegationResponse, error) {
+func (q Querier) ValidatorDelegation(c context.Context, req *types.QueryValidatorDelegationRequest) (*types.QueryValidatorDelegationResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -154,7 +154,7 @@ func (q grpcQuerier) ValidatorDelegation(c context.Context, req *types.QueryVali
 	}, nil
 }
 
-func (q grpcQuerier) ValidatorUnbondingDelegations(c context.Context, req *types.QueryValidatorUnbondingDelegationsRequest) (*types.QueryValidatorUnbondingDelegationsResponse, error) {
+func (q Querier) ValidatorUnbondingDelegations(c context.Context, req *types.QueryValidatorUnbondingDelegationsRequest) (*types.QueryValidatorUnbondingDelegationsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -171,7 +171,7 @@ func (q grpcQuerier) ValidatorUnbondingDelegations(c context.Context, req *types
 	return &types.QueryValidatorUnbondingDelegationsResponse{Entries: unbodings}, nil
 }
 
-func (q grpcQuerier) HistoricalInfo(c context.Context, req *stakingtypes.QueryHistoricalInfoRequest) (*stakingtypes.QueryHistoricalInfoResponse, error) {
+func (q Querier) HistoricalInfo(c context.Context, req *stakingtypes.QueryHistoricalInfoRequest) (*stakingtypes.QueryHistoricalInfoResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -183,7 +183,7 @@ func (q grpcQuerier) HistoricalInfo(c context.Context, req *stakingtypes.QueryHi
 	return &stakingtypes.QueryHistoricalInfoResponse{Hist: &hi}, nil
 }
 
-func (q grpcQuerier) ValidatorOutstandingReward(c context.Context, req *types.QueryValidatorOutstandingRewardRequest) (*types.QueryValidatorOutstandingRewardResponse, error) {
+func (q Querier) ValidatorOutstandingReward(c context.Context, req *types.QueryValidatorOutstandingRewardRequest) (*types.QueryValidatorOutstandingRewardResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}

--- a/x/poe/keeper/querier_test.go
+++ b/x/poe/keeper/querier_test.go
@@ -58,7 +58,7 @@ func TestQueryContractAddress(t *testing.T) {
 	}
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
-			q := NewGrpcQuerier(PoEKeeperMock{GetPoEContractAddressFn: spec.mockFn})
+			q := NewQuerier(PoEKeeperMock{GetPoEContractAddressFn: spec.mockFn})
 			ctx := sdk.Context{}.WithContext(context.Background())
 			gotRes, gotErr := q.ContractAddress(sdk.WrapSDKContext(ctx), &spec.srcMsg)
 			if spec.expErrCode != 0 {
@@ -143,7 +143,7 @@ func TestQueryValidators(t *testing.T) {
 			ctx := sdk.WrapSDKContext(sdk.Context{}.WithContext(context.Background()))
 			poeKeeper.ValsetContractFn = func(ctx sdk.Context) ValsetContract { return spec.mock }
 			// when
-			s := NewGrpcQuerier(poeKeeper)
+			s := NewQuerier(poeKeeper)
 			gotRes, gotErr := s.Validators(ctx, spec.src)
 
 			// then
@@ -210,7 +210,7 @@ func TestQueryValidator(t *testing.T) {
 			ctx := sdk.WrapSDKContext(sdk.Context{}.WithContext(context.Background()))
 			poeKeeper := PoEKeeperMock{ValsetContractFn: func(ctx sdk.Context) ValsetContract { return spec.mock }}
 			// when
-			s := NewGrpcQuerier(poeKeeper)
+			s := NewQuerier(poeKeeper)
 			gotRes, gotErr := s.Validator(ctx, spec.src)
 
 			// then
@@ -259,7 +259,7 @@ func TestQueryUnbondingPeriod(t *testing.T) {
 			}}
 
 			// when
-			s := NewGrpcQuerier(poeKeeper)
+			s := NewQuerier(poeKeeper)
 			gotRes, gotErr := s.UnbondingPeriod(ctx, spec.src)
 
 			// then
@@ -318,7 +318,7 @@ func TestValidatorDelegation(t *testing.T) {
 				return spec.mock
 			}
 			// when
-			q := NewGrpcQuerier(poeKeeper)
+			q := NewQuerier(poeKeeper)
 			gotRes, gotErr := q.ValidatorDelegation(ctx, spec.src)
 
 			// then
@@ -396,7 +396,7 @@ func TestValidatorUnbondingDelegations(t *testing.T) {
 				return spec.mock
 			}
 			// when
-			q := NewGrpcQuerier(poeKeeper)
+			q := NewQuerier(poeKeeper)
 			gotRes, gotErr := q.ValidatorUnbondingDelegations(ctx, spec.src)
 
 			// then
@@ -452,7 +452,7 @@ func TestValidatorOutstandingReward(t *testing.T) {
 
 			c := sdk.WrapSDKContext(sdk.Context{}.WithContext(context.Background()))
 			// when
-			s := NewGrpcQuerier(keeperMock)
+			s := NewQuerier(keeperMock)
 			gotResp, gotErr := s.ValidatorOutstandingReward(c, spec.src)
 			// then
 			if spec.expErr != nil {

--- a/x/poe/keeper/test_common.go
+++ b/x/poe/keeper/test_common.go
@@ -94,7 +94,7 @@ type TestKeepers struct {
 	GovKeeper      govkeeper.Keeper
 	TWasmKeeper    *twasmkeeper.Keeper
 	IBCKeeper      *ibckeeper.Keeper
-	PoEKeeper      Keeper
+	PoEKeeper      *Keeper
 	EncodingConfig params2.EncodingConfig
 	UpgradeKeeper  upgradekeeper.Keeper
 	Faucet         *wasmkeeper.TestFaucet
@@ -320,7 +320,7 @@ func createTestInput(
 		TWasmKeeper:    &twasmKeeper,
 		BankKeeper:     bankKeeper,
 		IBCKeeper:      ibcKeeper,
-		PoEKeeper:      poeKeeper,
+		PoEKeeper:      &poeKeeper,
 		UpgradeKeeper:  upgradeKeeper,
 		EncodingConfig: encodingConfig,
 		BaseApp:        consensusParamsUpdater,

--- a/x/poe/keeper/test_common.go
+++ b/x/poe/keeper/test_common.go
@@ -10,7 +10,6 @@ import (
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
-	params2 "github.com/cosmos/cosmos-sdk/simapp/params"
 	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -80,7 +79,7 @@ var moduleBasics = module.NewBasicManager(
 	twasm.AppModuleBasic{},
 )
 
-func makeEncodingConfig(t testing.TB) params2.EncodingConfig {
+func makeEncodingConfig(t testing.TB) simappparams.EncodingConfig {
 	r := types.MakeEncodingConfig(t)
 	moduleBasics.RegisterLegacyAminoCodec(r.Amino)
 	moduleBasics.RegisterInterfaces(r.InterfaceRegistry)
@@ -95,7 +94,7 @@ type TestKeepers struct {
 	TWasmKeeper    *twasmkeeper.Keeper
 	IBCKeeper      *ibckeeper.Keeper
 	PoEKeeper      *Keeper
-	EncodingConfig params2.EncodingConfig
+	EncodingConfig simappparams.EncodingConfig
 	UpgradeKeeper  upgradekeeper.Keeper
 	Faucet         *wasmkeeper.TestFaucet
 	BaseApp        *baseapp.BaseApp
@@ -347,7 +346,7 @@ func RandomAddress(_ *testing.T) sdk.AccAddress {
 }
 
 // createMinTestInput minimum integration test setup for this package
-func createMinTestInput(t *testing.T) (sdk.Context, simappparams.EncodingConfig, Keeper) {
+func createMinTestInput(t *testing.T) (sdk.Context, simappparams.EncodingConfig, *Keeper) { //nolint:deadcode,unused
 	var (
 		keyPoe     = sdk.NewKVStoreKey(types.StoreKey)
 		keyParams  = sdk.NewKVStoreKey(paramstypes.StoreKey)
@@ -395,5 +394,5 @@ func createMinTestInput(t *testing.T) (sdk.Context, simappparams.EncodingConfig,
 	}, false, log.NewNopLogger())
 
 	k := NewKeeper(encodingConfig.Marshaler, keyPoe, paramsKeeper.Subspace(types.ModuleName), nil, accountKeeper)
-	return ctx, encodingConfig, k
+	return ctx, encodingConfig, &k
 }

--- a/x/poe/keeper/test_mocks.go
+++ b/x/poe/keeper/test_mocks.go
@@ -139,7 +139,7 @@ func (m SmartQuerierMock) QuerySmart(ctx sdk.Context, contractAddr sdk.AccAddres
 }
 
 // return matching type or fail
-func newContractSourceMock(t *testing.T, myValsetContract sdk.AccAddress, myStakingContract sdk.AccAddress) PoEKeeperMock {
+func newContractSourceMock(t *testing.T, myValsetContract sdk.AccAddress, myStakingContract sdk.AccAddress) PoEKeeperMock { //nolint:deadcode,unused
 	return PoEKeeperMock{
 		GetPoEContractAddressFn: SwitchPoEContractAddressFn(t, myValsetContract, myStakingContract),
 	}

--- a/x/poe/module_test.go
+++ b/x/poe/module_test.go
@@ -32,7 +32,7 @@ func TestInitGenesis(t *testing.T) {
 	ctx, example := keeper.CreateDefaultTestInput(t)
 	ctx = ctx.WithBlockHeight(0)
 	deliverTXFn := unAuthorizedDeliverTXFn(t, ctx, example.PoEKeeper, example.TWasmKeeper.GetContractKeeper(), example.EncodingConfig.TxConfig.TxDecoder())
-	app := NewAppModule(&example.PoEKeeper, example.TWasmKeeper, example.BankKeeper, example.AccountKeeper, deliverTXFn, example.EncodingConfig.TxConfig, example.TWasmKeeper.GetContractKeeper())
+	app := NewAppModule(example.PoEKeeper, example.TWasmKeeper, example.BankKeeper, example.AccountKeeper, deliverTXFn, example.EncodingConfig.TxConfig, example.TWasmKeeper.GetContractKeeper())
 
 	const numValidators = 15
 	mutator, myValidators := withRandomValidators(t, ctx, example, numValidators)
@@ -204,7 +204,7 @@ func queryAllMembers(t *testing.T, ctx sdk.Context, k *twasmkeeper.Keeper, addr 
 }
 
 // unAuthorizedDeliverTXFn applies the TX without ante handler checks for testing purpose
-func unAuthorizedDeliverTXFn(t *testing.T, ctx sdk.Context, k keeper.Keeper, contractKeeper wasmtypes.ContractOpsKeeper, txDecoder sdk.TxDecoder) func(tx abci.RequestDeliverTx) abci.ResponseDeliverTx {
+func unAuthorizedDeliverTXFn(t *testing.T, ctx sdk.Context, k *keeper.Keeper, contractKeeper wasmtypes.ContractOpsKeeper, txDecoder sdk.TxDecoder) func(tx abci.RequestDeliverTx) abci.ResponseDeliverTx {
 	t.Helper()
 	h := NewHandler(k, contractKeeper, nil)
 	return func(tx abci.RequestDeliverTx) abci.ResponseDeliverTx {

--- a/x/poe/simulation/genesis.go
+++ b/x/poe/simulation/genesis.go
@@ -33,7 +33,7 @@ func RandomizedGenState(simState *module.SimulationState) {
 		if len(v) == 0 {
 			continue
 		}
-		simState.GenState[k] = []byte(strings.Replace(string(v), "\"stake\"", fmt.Sprintf("%q", defaultDenom), -1))
+		simState.GenState[k] = []byte(strings.ReplaceAll(string(v), "\"stake\"", fmt.Sprintf("%q", defaultDenom)))
 	}
 
 	// ensure bank module state for PoE
@@ -61,24 +61,24 @@ func RandomizedGenState(simState *module.SimulationState) {
 	}
 
 	// add some random oversight community members
-	var ocMembers []string
 	opMembersCount := math.MinInt(simState.Rand.Int()+1, len(simState.Accounts)-int(simState.NumBonded))
+	ocMembers := make([]string, opMembersCount)
 	for i := 0; i < opMembersCount; i++ {
-		ocMembers = append(ocMembers, simState.Accounts[int(simState.NumBonded)+i].Address.String())
+		ocMembers[i] = simState.Accounts[int(simState.NumBonded)+i].Address.String()
 	}
 
 	// add some random arbiter pool members
-	var apMembers []string
 	apMembersCount := math.MinInt(simState.Rand.Int()+1, len(simState.Accounts)-int(simState.NumBonded))
+	apMembers := make([]string, apMembersCount)
 	for i := 0; i < apMembersCount; i++ {
-		apMembers = append(apMembers, simState.Accounts[int(simState.NumBonded)+i].Address.String())
+		apMembers[i] = simState.Accounts[int(simState.NumBonded)+i].Address.String()
 	}
 
 	txConfig := types.MakeEncodingConfig(nil).TxConfig
 
 	// prepare genTX
-	var genTxs []json.RawMessage
-	var engagements []types.TG4Member
+	genTxs := make([]json.RawMessage, 0, int(simState.NumBonded))
+	engagements := make([]types.TG4Member, 0, int(simState.NumBonded))
 	for i := 1; i < int(simState.NumBonded); i++ {
 		acc := simState.Accounts[i]
 		if acc.Address.String() != bankGenesis.Balances[i].Address {
@@ -126,7 +126,7 @@ func RandomizedGenState(simState *module.SimulationState) {
 		}
 
 		// Second round: all signer infos are set, so each signer can sign.
-		var seq uint64 = 0
+		var seq uint64
 		data := authsigning.SignerData{
 			ChainID:       sdkhelpers.SimAppChainID,
 			AccountNumber: 0, // in genesis

--- a/x/poe/simulation/genesis.go
+++ b/x/poe/simulation/genesis.go
@@ -5,9 +5,7 @@ package simulation
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"strings"
-	"time"
 
 	"github.com/tendermint/tendermint/libs/math"
 
@@ -16,7 +14,6 @@ import (
 	sdkhelpers "github.com/cosmos/cosmos-sdk/simapp/helpers"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -25,24 +22,7 @@ import (
 	"github.com/confio/tgrade/x/poe/types"
 )
 
-// Simulation parameter constants
-const (
-	unbondingTime     = "unbonding_time"
-	maxValidators     = "max_validators"
-	historicalEntries = "historical_entries"
-)
-
 const defaultDenom = "utgd"
-
-// GenUnbondingTime randomized UnbondingTime
-func genUnbondingTime(r *rand.Rand) (ubdTime time.Duration) {
-	return time.Duration(simulation.RandIntBetween(r, 60, 60*60*24*3*2)) * time.Second
-}
-
-// GenMaxValidators randomized MaxValidators
-func genMaxValidators(r *rand.Rand) (maxValidators uint32) {
-	return uint32(r.Intn(250) + 1)
-}
 
 // RandomizedGenState generates a random GenesisState
 func RandomizedGenState(simState *module.SimulationState) {

--- a/x/poe/simulation/operations.go
+++ b/x/poe/simulation/operations.go
@@ -31,8 +31,8 @@ const (
 // BankKeeper extended bank keeper used by simulations
 type BankKeeper interface {
 	types.BankKeeper
+	simulation.BankKeeper
 	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
-	SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 }
 
 // subset used in simulations
@@ -170,7 +170,7 @@ func SimulateMsgCreateValidator(bk BankKeeper, ak types.AccountKeeper, k poeKeep
 }
 
 // SimulateMsgUpdateValidator generates a MsgUpdateValidator with random values
-func SimulateMsgUpdateValidator(bk BankKeeper, ak types.AccountKeeper, k poeKeeper) simtypes.Operation {
+func SimulateMsgUpdateValidator(bk simulation.BankKeeper, ak types.AccountKeeper, k poeKeeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
@@ -273,7 +273,7 @@ func SimulateMsgDelegate(bk BankKeeper, ak types.AccountKeeper, k poeKeeper) sim
 }
 
 // SimulateMsgUndelegate generates a MsgUndelegate with random values
-func SimulateMsgUndelegate(bk BankKeeper, ak types.AccountKeeper, k poeKeeper) simtypes.Operation {
+func SimulateMsgUndelegate(bk simulation.BankKeeper, ak types.AccountKeeper, k poeKeeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {

--- a/x/poe/stakingadapter/keeper.go
+++ b/x/poe/stakingadapter/keeper.go
@@ -125,16 +125,16 @@ func (s StakingAdapter) BondedRatio(ctx sdk.Context) sdk.Dec {
 	return sdk.ZeroDec()
 }
 
-func (s2 StakingAdapter) IterateBondedValidatorsByPower(ctx sdk.Context, f func(index int64, validator stakingtypes.ValidatorI) (stop bool)) {
+func (s StakingAdapter) IterateBondedValidatorsByPower(ctx sdk.Context, f func(index int64, validator stakingtypes.ValidatorI) (stop bool)) {
 	log(ctx, "IterateBondedValidatorsByPower")
 }
 
-func (s2 StakingAdapter) TotalBondedTokens(ctx sdk.Context) sdk.Int {
+func (s StakingAdapter) TotalBondedTokens(ctx sdk.Context) sdk.Int {
 	log(ctx, "TotalBondedTokens")
 	return sdk.NewInt(0)
 }
 
-func (s2 StakingAdapter) IterateDelegations(ctx sdk.Context, delegator sdk.AccAddress, fn func(index int64, delegation stakingtypes.DelegationI) (stop bool)) {
+func (s StakingAdapter) IterateDelegations(ctx sdk.Context, delegator sdk.AccAddress, fn func(index int64, delegation stakingtypes.DelegationI) (stop bool)) {
 	log(ctx, "IterateDelegations")
 }
 

--- a/x/poe/types/params.go
+++ b/x/poe/types/params.go
@@ -60,9 +60,12 @@ func DefaultParams() Params {
 	)
 }
 
-// String returns a human readable string representation of the parameters.
+// String returns a human-readable string representation of the parameters.
 func (p Params) String() string {
-	out, _ := yaml.Marshal(p)
+	out, err := yaml.Marshal(p)
+	if err != nil {
+		out = []byte(fmt.Sprintf("failed to serialize: %s", err))
+	}
 	return string(out)
 }
 

--- a/x/poe/types/test_common.go
+++ b/x/poe/types/test_common.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/testutil"
+
 	"github.com/cosmos/cosmos-sdk/types/address"
 
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -12,7 +14,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
-	"github.com/cosmos/cosmos-sdk/server"
 	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 	"github.com/cosmos/cosmos-sdk/std"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -61,7 +62,7 @@ func RandomGenTX(t *testing.T, power uint32, mutators ...func(*MsgCreateValidato
 	algo, err := keyring.NewSigningAlgoFromString(string(hd.Secp256k1Type), keyringAlgos)
 	require.NoError(t, err)
 	const myKey = "myKey"
-	addr, _, err := server.GenerateSaveCoinKey(kb, myKey, true, algo)
+	addr, _, err := testutil.GenerateSaveCoinKey(kb, myKey, "", true, algo)
 	require.NoError(t, err)
 
 	// prepare genesis tx

--- a/x/twasm/client/cli/query.go
+++ b/x/twasm/client/cli/query.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"encoding/base64"
 	"fmt"
 	"strings"
 
@@ -9,7 +8,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
 
 	"github.com/confio/tgrade/x/twasm/types"
 )
@@ -94,20 +92,4 @@ func GetCmdListPrivilegedContracts() *cobra.Command {
 	}
 	flags.AddQueryFlagsToCmd(cmd)
 	return cmd
-}
-
-// sdk ReadPageRequest expects binary but we encoded to base64 in our marshaller
-func withPageKeyDecoded(flagSet *flag.FlagSet) *flag.FlagSet {
-	encoded, err := flagSet.GetString(flags.FlagPageKey)
-	if err != nil {
-		panic(err.Error())
-	}
-	raw, err := base64.StdEncoding.DecodeString(encoded)
-	if err != nil {
-		panic(err.Error())
-	}
-	if err := flagSet.Set(flags.FlagPageKey, string(raw)); err != nil {
-		panic(err.Error())
-	}
-	return flagSet
 }

--- a/x/twasm/contract/incoming_msgs.go
+++ b/x/twasm/contract/incoming_msgs.go
@@ -130,9 +130,10 @@ func (p ExecuteGovProposal) GetProposalContent(sender sdk.AccAddress) govtypes.C
 // unpackInterfaces unpacks the Any type into the interface type in `Any.cachedValue`
 func (p *ExecuteGovProposal) unpackInterfaces(unpacker codectypes.AnyUnpacker) error {
 	var err error
-	switch {
+	switch { //nolint:gocritic
 	case p.Proposal.RegisterUpgrade != nil:
-		if p.Proposal.RegisterUpgrade.UpgradedClientState != nil {
+		// revisit with https://github.com/confio/tgrade/issues/364
+		if p.Proposal.RegisterUpgrade.UpgradedClientState != nil { //nolint:staticcheck
 			return sdkerrors.ErrInvalidRequest.Wrap("upgrade logic for IBC has been moved to the IBC module")
 		}
 	}
@@ -141,14 +142,14 @@ func (p *ExecuteGovProposal) unpackInterfaces(unpacker codectypes.AnyUnpacker) e
 
 // ProtoAny data type to map from json to cosmos-sdk Any type.
 type ProtoAny struct {
-	TypeUrl string `json:"type_url"`
+	TypeURL string `json:"type_url"`
 	Value   []byte `json:"value"`
 }
 
 // Encode converts to a cosmos-sdk Any type.
 func (a ProtoAny) Encode() *codectypes.Any {
 	return &codectypes.Any{
-		TypeUrl: a.TypeUrl,
+		TypeUrl: a.TypeURL,
 		Value:   a.Value,
 	}
 }
@@ -170,14 +171,14 @@ func (p *GovProposal) UnmarshalJSON(b []byte) error {
 	customUnmarshalers := map[string]func(b []byte) error{
 		"ibc_client_update": func(b []byte) error {
 			proxy := struct {
-				ClientId string    `json:"client_id"`
+				ClientID string    `json:"client_id"`
 				Header   *ProtoAny `json:"header"`
 			}{}
 			if err := json.Unmarshal(b, &proxy); err != nil {
 				return sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
 			}
 			result.IBCClientUpdate = &ibcclienttypes.ClientUpdateProposal{
-				SubjectClientId: proxy.ClientId,
+				SubjectClientId: proxy.ClientID,
 			}
 			return nil
 		},

--- a/x/twasm/contract/incoming_msgs_test.go
+++ b/x/twasm/contract/incoming_msgs_test.go
@@ -12,7 +12,6 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	proposaltypes "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 	ibcclienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 	ibctmtypes "github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types"
 	"github.com/stretchr/testify/assert"
@@ -25,7 +24,7 @@ func TestGetProposalContent(t *testing.T) {
 	mySenderContractAddr := types.RandomAddress(t)
 
 	ir := codectypes.NewInterfaceRegistry()
-	clienttypes.RegisterInterfaces(ir)
+	ibcclienttypes.RegisterInterfaces(ir)
 	ibctmtypes.RegisterInterfaces(ir)
 
 	specs := map[string]struct {

--- a/x/twasm/keeper/keeper.go
+++ b/x/twasm/keeper/keeper.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/tendermint/tendermint/libs/log"
@@ -29,8 +28,8 @@ func NewKeeper(
 	cdc codec.Codec,
 	storeKey sdk.StoreKey,
 	paramSpace paramtypes.Subspace,
-	accountKeeper authkeeper.AccountKeeper,
-	bankKeeper types.BankKeeper,
+	accountKeeper wasmtypes.AccountKeeper,
+	bankKeeper wasmtypes.BankKeeper,
 	stakingKeeper wasmtypes.StakingKeeper,
 	distKeeper wasmtypes.DistributionKeeper,
 	channelKeeper wasmtypes.ChannelKeeper,

--- a/x/twasm/keeper/privileged.go
+++ b/x/twasm/keeper/privileged.go
@@ -232,7 +232,7 @@ func (k Keeper) removePrivilegeRegistration(ctx sdk.Context, privilegeType types
 }
 
 // getPrivilegedContract returns the key stored at the given type and position. Result can be nil when none exists
-func (k Keeper) getPrivilegedContract(ctx sdk.Context, privilegeType types.PrivilegeType, pos uint8) sdk.AccAddress {
+func (k Keeper) getPrivilegedContract(ctx sdk.Context, privilegeType types.PrivilegeType, pos uint8) sdk.AccAddress { //nolint:unused
 	store := ctx.KVStore(k.storeKey)
 	key := contractPrivilegesSecondaryIndexKey(privilegeType, pos)
 	return store.Get(key)

--- a/x/twasm/keeper/querier.go
+++ b/x/twasm/keeper/querier.go
@@ -10,22 +10,22 @@ import (
 	"github.com/confio/tgrade/x/twasm/types"
 )
 
-var _ types.QueryServer = &grpcQuerier{}
+var _ types.QueryServer = &Querier{}
 
 // queryKeeper is a subset of the keeper's methods
 type queryKeeper interface {
 	IteratePrivileged(ctx sdk.Context, cb func(sdk.AccAddress) bool)
 	IteratePrivilegedContractsByType(ctx sdk.Context, privilegeType types.PrivilegeType, cb func(prio uint8, contractAddr sdk.AccAddress) bool)
 }
-type grpcQuerier struct {
+type Querier struct {
 	keeper queryKeeper
 }
 
-func NewGrpcQuerier(keeper queryKeeper) *grpcQuerier {
-	return &grpcQuerier{keeper: keeper}
+func NewQuerier(keeper queryKeeper) *Querier {
+	return &Querier{keeper: keeper}
 }
 
-func (q grpcQuerier) PrivilegedContracts(c context.Context, _ *types.QueryPrivilegedContractsRequest) (*types.QueryPrivilegedContractsResponse, error) {
+func (q Querier) PrivilegedContracts(c context.Context, _ *types.QueryPrivilegedContractsRequest) (*types.QueryPrivilegedContractsResponse, error) {
 	var result types.QueryPrivilegedContractsResponse
 	q.keeper.IteratePrivileged(sdk.UnwrapSDKContext(c), func(address sdk.AccAddress) bool {
 		result.Contracts = append(result.Contracts, address.String())
@@ -34,7 +34,7 @@ func (q grpcQuerier) PrivilegedContracts(c context.Context, _ *types.QueryPrivil
 	return &result, nil
 }
 
-func (q grpcQuerier) ContractsByPrivilegeType(c context.Context, req *types.QueryContractsByPrivilegeTypeRequest) (*types.QueryContractsByPrivilegeTypeResponse, error) {
+func (q Querier) ContractsByPrivilegeType(c context.Context, req *types.QueryContractsByPrivilegeTypeRequest) (*types.QueryContractsByPrivilegeTypeResponse, error) {
 	var result types.QueryContractsByPrivilegeTypeResponse
 	cType := types.PrivilegeTypeFrom(req.PrivilegeType)
 	if cType == nil {

--- a/x/twasm/keeper/querier_test.go
+++ b/x/twasm/keeper/querier_test.go
@@ -48,7 +48,7 @@ func TestQueryPrivilegedContracts(t *testing.T) {
 				},
 			}
 
-			q := NewGrpcQuerier(mock)
+			q := NewQuerier(mock)
 			// when
 			gotRsp, gotErr := q.PrivilegedContracts(sdk.WrapSDKContext(ctx), nil)
 			// then
@@ -116,7 +116,7 @@ func TestQueryContractsByPrivilegeType(t *testing.T) {
 				},
 			}
 
-			q := NewGrpcQuerier(mock)
+			q := NewQuerier(mock)
 			// when
 			gotRsp, gotErr := q.ContractsByPrivilegeType(sdk.WrapSDKContext(ctx), &spec.src)
 			// then

--- a/x/twasm/keeper/test_common.go
+++ b/x/twasm/keeper/test_common.go
@@ -292,7 +292,7 @@ func createTestInput(
 	)
 	keeper.setParams(ctx, types.DefaultParams())
 
-	types.RegisterQueryServer(querier, NewGrpcQuerier(keeper))
+	types.RegisterQueryServer(querier, NewQuerier(keeper))
 	// wasm services
 	wasmtypes.RegisterMsgServer(querier, wasmkeeper.NewMsgServerImpl(wasmkeeper.NewDefaultPermissionKeeper(keeper)))
 	wasmtypes.RegisterQueryServer(querier, WasmQuerier(&keeper))

--- a/x/twasm/simulation/operations.go
+++ b/x/twasm/simulation/operations.go
@@ -92,7 +92,7 @@ func WeightedOperations(
 		),
 		simulation.NewWeightedOperation(
 			weightMsgInstantiateContract,
-			SimulateMsgInstantiateContract(ak, bk, wasmKeeper, TgradeSimulationCodeIdSelector),
+			SimulateMsgInstantiateContract(ak, bk, wasmKeeper, TgradeSimulationCodeIDSelector),
 		),
 		simulation.NewWeightedOperation(
 			weightMsgExecuteContract,
@@ -337,7 +337,7 @@ func DefaultSimulationExecutePayloader(msg *wasmtypes.MsgExecuteContract) error 
 	return nil
 }
 
-func TgradeSimulationCodeIdSelector(ctx sdk.Context, wasmKeeper WasmKeeper) uint64 {
+func TgradeSimulationCodeIDSelector(ctx sdk.Context, wasmKeeper WasmKeeper) uint64 {
 	var codeID uint64
 	wasmKeeper.IterateCodeInfos(ctx, func(u uint64, info wasmtypes.CodeInfo) bool {
 		if info.InstantiateConfig.Permission != wasmtypes.AccessTypeEverybody ||

--- a/x/twasm/types/genesis.go
+++ b/x/twasm/types/genesis.go
@@ -91,8 +91,8 @@ func (g GenesisState) RawWasmState() wasmtypes.GenesisState {
 var _ codectypes.UnpackInterfacesMessage = GenesisState{}
 
 // UnpackInterfaces implements codectypes.UnpackInterfaces
-func (m GenesisState) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
-	for _, v := range m.Contracts {
+func (g GenesisState) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
+	for _, v := range g.Contracts {
 		if err := v.UnpackInterfaces(unpacker); err != nil {
 			return err
 		}

--- a/x/twasm/types/privilege.go
+++ b/x/twasm/types/privilege.go
@@ -11,9 +11,10 @@ import (
 // PrivilegeType is a system callback to a contract
 type PrivilegeType byte
 
+// PrivilegeTypeEmpty is empty value
+const PrivilegeTypeEmpty PrivilegeType = 0
+
 var (
-	// PrivilegeTypeEmpty is empty value
-	PrivilegeTypeEmpty PrivilegeType = 0
 
 	// PrivilegeTypeBeginBlock called every block before the TX are processed
 	// Multiple contracts can register for this callback privilege

--- a/x/twasm/types/privilege_test.go
+++ b/x/twasm/types/privilege_test.go
@@ -100,28 +100,28 @@ func TestPrivilegeTypeMarshalJson(t *testing.T) {
 	}
 	specs := map[string]struct {
 		src     interface{}
-		expJson []byte
+		expJSON []byte
 		expErr  bool
 	}{
 		"all good": {
 			src:     PrivilegeTypeBeginBlock,
-			expJson: []byte(`"begin_blocker"`),
+			expJSON: []byte(`"begin_blocker"`),
 		},
 		"obj value": {
 			src:     myTestType{Foo: PrivilegeTypeBeginBlock},
-			expJson: []byte(`{"foo":"begin_blocker"}`),
+			expJSON: []byte(`{"foo":"begin_blocker"}`),
 		},
 		"empty obj": {
 			src:     myTestType{},
-			expJson: []byte(`{}`),
+			expJSON: []byte(`{}`),
 		},
 		"ref": {
 			src:     &PrivilegeTypeBeginBlock,
-			expJson: []byte(`"begin_blocker"`),
+			expJSON: []byte(`"begin_blocker"`),
 		},
 		"empty ref": {
 			src:     (*PrivilegeType)(nil),
-			expJson: []byte(`null`),
+			expJSON: []byte(`null`),
 		},
 		"undefined": {
 			src:    PrivilegeTypeEmpty,
@@ -141,7 +141,7 @@ func TestPrivilegeTypeMarshalJson(t *testing.T) {
 				return
 			}
 			require.NoError(t, gotErr)
-			require.Equal(t, spec.expJson, gotVal)
+			require.Equal(t, spec.expJSON, gotVal)
 		})
 	}
 }


### PR DESCRIPTION
Address linter warnings
* Replace deprecated rules
* Ignore test files in linter run