### PR TITLE
Handle panic in valset update callback

### DIFF
--- a/x/poe/abci.go
+++ b/x/poe/abci.go
@@ -10,6 +10,7 @@ import (
 	"github.com/confio/tgrade/x/poe/contract"
 	"github.com/confio/tgrade/x/poe/keeper"
 	"github.com/confio/tgrade/x/poe/types"
+	"github.com/confio/tgrade/x/twasm"
 	twasmtypes "github.com/confio/tgrade/x/twasm/types"
 )
 
@@ -28,21 +29,30 @@ func EndBlocker(parentCtx sdk.Context, k endBlockKeeper) []abci.ValidatorUpdate 
 	k.IteratePrivilegedContractsByType(parentCtx, twasmtypes.PrivilegeTypeValidatorSetUpdate, func(pos uint8, contractAddr sdk.AccAddress) bool {
 		logger.Info("privileged contract callback", "type", twasmtypes.PrivilegeTypeValidatorSetUpdate.String())
 		ctx, commit := parentCtx.CacheContext()
+		defer twasm.RecoverToLog(logger, contractAddr)()
+
 		var err error
 		diff, err = contract.CallEndBlockWithValidatorUpdate(ctx, contractAddr, k)
 		if err != nil {
-			logger.Error("validator set update failed", "cause", err, "contract-address", contractAddr, "position", pos)
-			panic(err) // this will crash the node as panics are not recovered
+			logger.Error(
+				"contract callback for validator set update failed",
+				"cause", err,
+				"contract-address", contractAddr,
+				"position", pos,
+			)
+			return true // stop at first contract, without commit
 		}
 		commit()
 		if len(diff) != 0 {
 			logger.Info("update validator set", "new", diff)
 		}
+
 		return true // stop at first contract
 	})
 	return diff
 }
 
+// BeginBlocker ABCI begin block callback
 func BeginBlocker(ctx sdk.Context, k interface{ TrackHistoricalInfo(ctx sdk.Context) }) {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
 

--- a/x/poe/abci_test.go
+++ b/x/poe/abci_test.go
@@ -27,7 +27,6 @@ func TestEndBlock(t *testing.T) {
 	specs := map[string]struct {
 		setup           func(m *MockSudoer)
 		expSudoCalls    []tuple
-		expPanic        bool
 		expCommitted    []bool
 		expValsetUpdate []abci.ValidatorUpdate
 	}{
@@ -80,7 +79,7 @@ func TestEndBlock(t *testing.T) {
 				Power:  2,
 			}},
 		},
-		"valset update - panic not handled": {
+		"valset update - panic should be handled": {
 			setup: func(m *MockSudoer) {
 				m.SudoFn = func(ctx sdk.Context, contractAddress sdk.AccAddress, msg []byte) ([]byte, error) {
 					if contractAddress.Equals(myAddr) {
@@ -90,7 +89,6 @@ func TestEndBlock(t *testing.T) {
 				}
 				m.IteratePrivilegedContractsByTypeFn = endBlockTypeIterateContractsFn(t, nil, []sdk.AccAddress{myAddr})
 			},
-			expPanic: true,
 		},
 	}
 	for name, spec := range specs {
@@ -103,12 +101,6 @@ func TestEndBlock(t *testing.T) {
 				WithMultiStore(&commitMultistore)
 
 			// when
-			if spec.expPanic {
-				require.Panics(t, func() {
-					_ = EndBlocker(ctx, &mock)
-				})
-				return
-			}
 			gotValsetUpdate := EndBlocker(ctx, &mock)
 			assert.Equal(t, spec.expValsetUpdate, gotValsetUpdate)
 


### PR DESCRIPTION
Resolves #32 

Log errors/ panics on validator set update callback.

Note: this PR does not include a compile flag fail fast solution.