### PR TITLE
Do not require fees on simulation queries

### DIFF
--- a/x/globalfee/ante.go
+++ b/x/globalfee/ante.go
@@ -35,7 +35,7 @@ func NewGlobalMinimumChainFeeDecorator(paramSpace paramtypes.Subspace) GlobalMin
 
 // AnteHandle method that performs custom pre- and post-processing.
 func (g GlobalMinimumChainFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
-	if g.paramSource.Has(ctx, types.ParamStoreKeyMinGasPrices) {
+	if g.paramSource.Has(ctx, types.ParamStoreKeyMinGasPrices) && !simulate {
 		feeTx, ok := tx.(sdk.FeeTx)
 		if !ok {
 			return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "tx must be a sdk FeeTx")

--- a/x/globalfee/ante.go
+++ b/x/globalfee/ante.go
@@ -35,7 +35,7 @@ func NewGlobalMinimumChainFeeDecorator(paramSpace paramtypes.Subspace) GlobalMin
 
 // AnteHandle method that performs custom pre- and post-processing.
 func (g GlobalMinimumChainFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
-	if g.paramSource.Has(ctx, types.ParamStoreKeyMinGasPrices) && !simulate {
+	if !simulate && g.paramSource.Has(ctx, types.ParamStoreKeyMinGasPrices) {
 		feeTx, ok := tx.(sdk.FeeTx)
 		if !ok {
 			return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "tx must be a sdk FeeTx")


### PR DESCRIPTION
This fixes the issue where simulation queries are rejected without fees set.
Main purpose of simulation queries are to calculate the gas used for execution. Base on this gas value returned (and an adjustment value) the fee amount for the TX would be set by the CLI