### PR TITLE
New TgradeSnapshotter that restores cache after StateSync

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
-	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
@@ -578,7 +577,7 @@ func NewTgradeApp(
 	// see cmd/wasmd/root.go: 206 - 214 approx
 	if manager := app.SnapshotManager(); manager != nil {
 		err := manager.RegisterExtensions(
-			wasmkeeper.NewWasmSnapshotter(app.CommitMultiStore(), &app.twasmKeeper.Keeper),
+			NewTgradeSnapshotter(app, app.CommitMultiStore(), &app.twasmKeeper.Keeper),
 		)
 		if err != nil {
 			panic(fmt.Errorf("failed to register snapshot extension: %s", err))

--- a/app/snapshotter.go
+++ b/app/snapshotter.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"fmt"
+
+	snapshot "github.com/cosmos/cosmos-sdk/snapshots/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	protoio "github.com/gogo/protobuf/io"
+	tmos "github.com/tendermint/tendermint/libs/os"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	"github.com/CosmWasm/wasmd/x/wasm/keeper"
+)
+
+var _ snapshot.ExtensionSnapshotter = &TgradeSnapshotter{}
+
+type TgradeSnapshotter struct {
+	*keeper.WasmSnapshotter
+	app *TgradeApp
+}
+
+func NewTgradeSnapshotter(app *TgradeApp, cms sdk.MultiStore, wasm *keeper.Keeper) *TgradeSnapshotter {
+	return &TgradeSnapshotter{
+		WasmSnapshotter: keeper.NewWasmSnapshotter(cms, wasm),
+		app:             app,
+	}
+}
+
+func (t *TgradeSnapshotter) Restore(
+	height uint64, format uint32, protoReader protoio.Reader,
+) (snapshot.SnapshotItem, error) {
+	item, err := t.WasmSnapshotter.Restore(height, format, protoReader)
+	if err != nil {
+		ctx := t.app.BaseApp.NewUncachedContext(true, tmproto.Header{})
+
+		// Initialize pinned codes in wasmvm as they are not persisted there
+		if err := t.app.twasmKeeper.InitializePinnedCodes(ctx); err != nil {
+			tmos.Exit(fmt.Sprintf("failed initialize pinned codes %s", err))
+		}
+		t.app.poeKeeper.InitContractAddressCache(ctx)
+	}
+	return item, err
+}

--- a/app/snapshotter.go
+++ b/app/snapshotter.go
@@ -1,12 +1,9 @@
 package app
 
 import (
-	"fmt"
-
 	snapshot "github.com/cosmos/cosmos-sdk/snapshots/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	protoio "github.com/gogo/protobuf/io"
-	tmos "github.com/tendermint/tendermint/libs/os"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/CosmWasm/wasmd/x/wasm/keeper"
@@ -30,13 +27,9 @@ func (t *TgradeSnapshotter) Restore(
 	height uint64, format uint32, protoReader protoio.Reader,
 ) (snapshot.SnapshotItem, error) {
 	item, err := t.WasmSnapshotter.Restore(height, format, protoReader)
-	if err != nil {
+	if err == nil {
+		// pinned contract are initialized in WasmSnapshotter already
 		ctx := t.app.BaseApp.NewUncachedContext(true, tmproto.Header{})
-
-		// Initialize pinned codes in wasmvm as they are not persisted there
-		if err := t.app.twasmKeeper.InitializePinnedCodes(ctx); err != nil {
-			tmos.Exit(fmt.Sprintf("failed initialize pinned codes %s", err))
-		}
 		t.app.poeKeeper.InitContractAddressCache(ctx)
 	}
 	return item, err

--- a/app/snapshotter.go
+++ b/app/snapshotter.go
@@ -11,11 +11,14 @@ import (
 
 var _ snapshot.ExtensionSnapshotter = &TgradeSnapshotter{}
 
+// TgradeSnapshotter custom cosmos-sdk snapshotter that extends
+// the wasmd snapshotter to restore poe contract cache
 type TgradeSnapshotter struct {
 	*keeper.WasmSnapshotter
 	app *TgradeApp
 }
 
+// NewTgradeSnapshotter constructor
 func NewTgradeSnapshotter(app *TgradeApp, cms sdk.MultiStore, wasm *keeper.Keeper) *TgradeSnapshotter {
 	return &TgradeSnapshotter{
 		WasmSnapshotter: keeper.NewWasmSnapshotter(cms, wasm),
@@ -23,6 +26,7 @@ func NewTgradeSnapshotter(app *TgradeApp, cms sdk.MultiStore, wasm *keeper.Keepe
 	}
 }
 
+// Restore restores wasm files and caches
 func (t *TgradeSnapshotter) Restore(
 	height uint64, format uint32, protoReader protoio.Reader,
 ) (snapshot.SnapshotItem, error) {


### PR DESCRIPTION
Follow up from #411 

Ensure we call the init cache logic in all entry points:

1. Init from genesis (always working)
2. Restart from existing state (done in #411)
3. Connect via state sync (done here)

This should help with node stability ensuring identical db access in all forms of starting nodes.