### PR TITLE
Upgrade circleci golang docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,7 @@ executors:
   golang:
     docker:
       - image: cimg/go:1.17
-#        user: root # for local testing: https://github.com/CircleCI-Public/circleci-cli/issues/291
-    working_directory: /go/src/github.com/confio/tgrade
+    working_directory: /home/circleci/go/src/github.com/confio/tgrade
 
 commands:
   make:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   golang:
     docker:
-      - image: circleci/golang:1.17
+      - image: cimg/go:1.17
 #        user: root # for local testing: https://github.com/CircleCI-Public/circleci-cli/issues/291
     working_directory: /go/src/github.com/confio/tgrade
 


### PR DESCRIPTION
Resolves #116 

Docs: https://github.com/CircleCI-Public/cimg-go#changes-from-legacy-image