### PR TITLE
Revert proto-gen script changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ format: format-tools
 ###############################################################################
 ###                                Protobuf                                 ###
 ###############################################################################
-PROTO_BUILDER_IMAGE=tendermintdev/sdk-proto-gen@sha256:372dce7be2f465123e26459973ca798fc489ff2c75aeecd814c0ca8ced24faca
+PROTO_BUILDER_IMAGE=tendermintdev/sdk-proto-gen:v0.2
 PROTO_FORMATTER_IMAGE=tendermintdev/docker-build-proto@sha256:aabcfe2fc19c31c0f198d4cd26393f5e5ca9502d7ea3feafbfe972448fee7cae
 
 proto-all: proto-format proto-lint proto-gen format

--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -8,7 +8,7 @@ protoc_gen_gocosmos() {
     return 1
   fi
 
-  go install github.com/regen-network/cosmos-proto/protoc-gen-gocosmos@latest 2>/dev/null
+  go get github.com/regen-network/cosmos-proto/protoc-gen-gocosmos@latest 2>/dev/null
 }
 
 protoc_gen_gocosmos


### PR DESCRIPTION
Revert some changes  done during go 1.18 upgrade. See #443 

Bump proto-gen container to the version used by the SDK v0.45.x